### PR TITLE
Attribute to provide From<$source> impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ thiserror-impl = { version = "=1.0.0", path = "impl" }
 
 [dev-dependencies]
 anyhow = "1.0"
+trybuild = "1.0"
 
 [workspace]
 members = ["impl"]

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -62,6 +62,16 @@ pub fn is_source(field: &Field) -> Result<bool> {
     Ok(false)
 }
 
+pub fn is_from(field: &Field) -> Result<bool> {
+    for attr in &field.attrs {
+        if attr.path.is_ident("from") {
+            syn::parse2::<Nothing>(attr.tokens.clone())?;
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 pub fn display(attrs: &[Attribute]) -> Result<Option<Display>> {
     let mut display = None;
 

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -84,8 +84,12 @@ fn impl_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
     });
 
     let from_derive = from.map(|(from_member, from_type)| {
+        let backtrace_field = backtrace.map(|back| {
+            quote!(#back: std::backtrace::Backtrace::capture())
+        });
+
         let from_struct = match from_member {
-            Member::Named(ident) => quote!(Self { #ident: src_err}),
+            Member::Named(ident) => quote!(Self { #ident: src_err, #backtrace_field }),
             Member::Unnamed(_) => quote!(Self(src_err)),
         };
 

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -82,10 +82,15 @@ fn impl_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
     });
 
     let from_derive = from.map(|(from_member, from_type)| {
+        let from_struct = match from_member {
+            Member::Named(ident) => quote!(Self { #ident: src_err }),
+            Member::Unnamed(_) => quote!(Self(src_err)),
+        };
+
         quote! {
             impl #impl_generics std::convert::From<#from_type> for #ty #ty_generics #where_clause {
                 fn from(src_err: #from_type) -> Self {
-                    
+                    #from_struct
                 }
             }
         }

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -84,10 +84,8 @@ fn impl_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
     });
 
     let from_derive = from.map(|(from_member, from_type)| {
-        //TODO when we figure out whether to use `Option<Backtrace>` update the `unwrap`
-        let backtrace_field = backtrace.map(|backtrace| quote!(#backtrace: *(src_err.backtrace().unwrap()).clone()));
         let from_struct = match from_member {
-            Member::Named(ident) => quote!(Self { #ident: src_err, #backtrace_field}),
+            Member::Named(ident) => quote!(Self { #ident: src_err}),
             Member::Unnamed(_) => quote!(Self(src_err)),
         };
 

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -267,11 +267,11 @@ fn source_member<'a>(fields: impl IntoIterator<Item = &'a Field>, parent_span: &
     let mut res = None;
 
     for (i, field) in fields.into_iter().enumerate() {
-        if  source_member_count == 1 {
-            return Err(Error::new(*parent_span, "Only one `source` field allowed per struct or struct variant"));
-        }
-
         if field_is_source(&field)? {
+            if  source_member_count == 1 {
+                return Err(Error::new(*parent_span, "Only one `source` field allowed per struct or struct variant"));
+            }
+
             res = Some(member(i, &field.ident));
             source_member_count += 1;
         }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -7,7 +7,7 @@ mod fmt;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-#[proc_macro_derive(Error, attributes(error, source))]
+#[proc_macro_derive(Error, attributes(error, source, from))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input)

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -49,6 +49,14 @@ enum EnumError {
 }
 
 #[derive(Error, Debug)]
+struct BracedImpliedSource {
+    source: io::Error,
+// this should cause compilation error
+//    #[source]
+//    cause: io::Error,
+}
+
+#[derive(Error, Debug)]
 struct BracedWithFrom {
     #[source]
     #[from]
@@ -75,6 +83,7 @@ unimplemented_display!(UnitError);
 unimplemented_display!(WithSource);
 unimplemented_display!(WithAnyhow);
 unimplemented_display!(EnumError);
+unimplemented_display!(BracedImpliedSource);
 unimplemented_display!(BracedWithFrom);
 unimplemented_display!(TupleWithFrom);
 unimplemented_display!(EnumWithFrom);

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -48,9 +48,21 @@ enum EnumError {
     Unit,
 }
 
+#[derive(Error, Debug)]
+struct BracedWithFrom{
+    #[source]
+    #[from]
+    cause: io::Error,
+}
+
+#[derive(Error, Debug)]
+struct TupleWithFrom( #[source] #[from] io::Error);
+
 unimplemented_display!(BracedError);
 unimplemented_display!(TupleError);
 unimplemented_display!(UnitError);
 unimplemented_display!(WithSource);
 unimplemented_display!(WithAnyhow);
 unimplemented_display!(EnumError);
+unimplemented_display!(BracedWithFrom);
+unimplemented_display!(TupleWithFrom);

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -51,9 +51,6 @@ enum EnumError {
 #[derive(Error, Debug)]
 struct BracedImpliedSource {
     source: io::Error,
-// this should cause compilation error
-//    #[source]
-//    cause: io::Error,
 }
 
 #[derive(Error, Debug)]

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
+#![feature(backtrace)]
 
+use std::backtrace::Backtrace;
 use std::fmt::{self, Display};
 use std::io;
 use thiserror::Error;
@@ -73,6 +75,14 @@ enum EnumWithFrom {
     Unit,
 }
 
+#[derive(Error, Debug)]
+struct BracedWithFromBacktrace {
+    #[from]
+    cause: io::Error,
+    backtrace: Backtrace,
+}
+
+
 unimplemented_display!(BracedError);
 unimplemented_display!(TupleError);
 unimplemented_display!(UnitError);
@@ -83,3 +93,4 @@ unimplemented_display!(BracedImpliedSource);
 unimplemented_display!(BracedWithFrom);
 unimplemented_display!(TupleWithFrom);
 unimplemented_display!(EnumWithFrom);
+unimplemented_display!(BracedWithFromBacktrace);

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -30,6 +30,7 @@ struct UnitError;
 struct WithSource {
     #[source]
     cause: io::Error,
+    msg: String,
 }
 
 #[derive(Error, Debug)]

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -56,22 +56,20 @@ struct BracedImpliedSource {
 
 #[derive(Error, Debug)]
 struct BracedWithFrom {
-    #[source]
     #[from]
     cause: io::Error,
 }
 
 #[derive(Error, Debug)]
-struct TupleWithFrom( #[source] #[from] io::Error);
+struct TupleWithFrom(#[from] io::Error);
 
 #[derive(Error, Debug)]
 enum EnumWithFrom {
     BracedOne {
-        #[source]
         #[from]
         cause: io::Error,
     },
-    Tuple(#[source] #[from] anyhow::Error),
+    Tuple(#[from] anyhow::Error),
     Unit,
 }
 

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -49,7 +49,7 @@ enum EnumError {
 }
 
 #[derive(Error, Debug)]
-struct BracedWithFrom{
+struct BracedWithFrom {
     #[source]
     #[from]
     cause: io::Error,
@@ -57,6 +57,17 @@ struct BracedWithFrom{
 
 #[derive(Error, Debug)]
 struct TupleWithFrom( #[source] #[from] io::Error);
+
+#[derive(Error, Debug)]
+enum EnumWithFrom {
+    BracedOne {
+        #[source]
+        #[from]
+        cause: io::Error,
+    },
+    Tuple(#[source] #[from] anyhow::Error),
+    Unit,
+}
 
 unimplemented_display!(BracedError);
 unimplemented_display!(TupleError);
@@ -66,3 +77,4 @@ unimplemented_display!(WithAnyhow);
 unimplemented_display!(EnumError);
 unimplemented_display!(BracedWithFrom);
 unimplemented_display!(TupleWithFrom);
+unimplemented_display!(EnumWithFrom);

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/tests/ui/from_source.rs
+++ b/tests/ui/from_source.rs
@@ -40,13 +40,4 @@ struct BracedWithFromExtraField1 {
     msg: String,
 }
 
-#[derive(Error, Debug)]
-struct BracedWithFromExtraField2 {
-    // this should cause compilation error
-    // because fields other than `from` are not allowed (except backtrace in future)
-    msg: String,
-    #[from]
-    source: io::Error,
-}
-
 fn main() {}

--- a/tests/ui/from_source.rs
+++ b/tests/ui/from_source.rs
@@ -1,0 +1,12 @@
+use std::io;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+struct BracedWithSourceDuplicate {
+    source: io::Error,
+// this should cause compilation error
+    #[source]
+    cause: io::Error,
+}
+
+fn main() {}

--- a/tests/ui/from_source.rs
+++ b/tests/ui/from_source.rs
@@ -4,8 +4,8 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 struct BracedWithSourceDuplicate {
     source: io::Error,
-// this should cause compilation error
-// becuase there's two `source`
+    // this should cause compilation error
+    // becuase there's two `source`
     #[source]
     cause: io::Error,
 }
@@ -14,8 +14,8 @@ struct BracedWithSourceDuplicate {
 struct BracedWithFromDuplicate1 {
     #[from]
     source: io::Error,
-// this should cause compilation error
-// because there's two `from`
+    // this should cause compilation error
+    // because there's two `from`
     #[from]
     cause: io::Error,
 }
@@ -23,10 +23,30 @@ struct BracedWithFromDuplicate1 {
 #[derive(Error, Debug)]
 struct BracedWithFromDuplicateSource {
     source: io::Error,
-// this should cause compilation error
-// because from implies source
+    // this should cause compilation error
+    // because from implies source
+    //
+    // TODO should this error actually be that there's a from tha't not on source?
     #[from]
     cause: io::Error,
+}
+
+#[derive(Error, Debug)]
+struct BracedWithFromExtraField1 {
+    #[from]
+    source: io::Error,
+    // this should cause compilation error
+    // because fields other than `from` are not allowed (except backtrace in future)
+    msg: String,
+}
+
+#[derive(Error, Debug)]
+struct BracedWithFromExtraField2 {
+    // this should cause compilation error
+    // because fields other than `from` are not allowed (except backtrace in future)
+    msg: String,
+    #[from]
+    source: io::Error,
 }
 
 fn main() {}

--- a/tests/ui/from_source.rs
+++ b/tests/ui/from_source.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 struct BracedWithSourceDuplicate {
     source: io::Error,
 // this should cause compilation error
+// becuase there's two `source`
     #[source]
     cause: io::Error,
 }
@@ -14,14 +15,16 @@ struct BracedWithFromDuplicate1 {
     #[from]
     source: io::Error,
 // this should cause compilation error
+// because there's two `from`
     #[from]
     cause: io::Error,
 }
 
 #[derive(Error, Debug)]
-struct BracedWithFromWithoutSource {
+struct BracedWithFromDuplicateSource {
     source: io::Error,
 // this should cause compilation error
+// because from implies source
     #[from]
     cause: io::Error,
 }

--- a/tests/ui/from_source.rs
+++ b/tests/ui/from_source.rs
@@ -40,4 +40,24 @@ struct BracedWithFromExtraField1 {
     msg: String,
 }
 
+#[derive(Error, Debug)]
+enum EnumDuplicateFromType1 {
+    BracedOne {
+        #[from]
+        cause: io::Error,
+    },
+    Tuple(#[from] io::Error),
+    Unit,
+}
+
+#[derive(Error, Debug)]
+enum EnumDuplicateFromType2 {
+    BracedOne {
+        #[from]
+        cause: io::Error,
+    },
+    Tuple(#[from] std::io::Error),
+    Unit,
+}
+
 fn main() {}

--- a/tests/ui/from_source.rs
+++ b/tests/ui/from_source.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::io::Error as IoError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -57,6 +58,16 @@ enum EnumDuplicateFromType2 {
         cause: io::Error,
     },
     Tuple(#[from] std::io::Error),
+    Unit,
+}
+
+#[derive(Error, Debug)]
+enum EnumDuplicateFromType3 {
+    BracedOne {
+        #[from]
+        cause: io::Error,
+    },
+    Tuple(#[from] IoError),
     Unit,
 }
 

--- a/tests/ui/from_source.rs
+++ b/tests/ui/from_source.rs
@@ -9,4 +9,21 @@ struct BracedWithSourceDuplicate {
     cause: io::Error,
 }
 
+#[derive(Error, Debug)]
+struct BracedWithFromDuplicate1 {
+    #[from]
+    source: io::Error,
+// this should cause compilation error
+    #[from]
+    cause: io::Error,
+}
+
+#[derive(Error, Debug)]
+struct BracedWithFromWithoutSource {
+    source: io::Error,
+// this should cause compilation error
+    #[from]
+    cause: io::Error,
+}
+
 fn main() {}

--- a/tests/ui/from_source.stderr
+++ b/tests/ui/from_source.stderr
@@ -1,35 +1,44 @@
 error: Only one `source` field allowed per struct or struct variant (remember that `#[from]` implies `source`)
-  --> $DIR/from_source.rs:10:5
+  --> $DIR/from_source.rs:11:5
    |
-10 |     cause: io::Error,
+11 |     cause: io::Error,
    |     ^^^^^
 
 error: Only one `#[from]` field allowed per struct or struct variant
-  --> $DIR/from_source.rs:20:5
+  --> $DIR/from_source.rs:21:5
    |
-20 |     cause: io::Error,
+21 |     cause: io::Error,
    |     ^^^^^
 
 error: When deriving `From`, non-`#[from]` fields are not allowed
-  --> $DIR/from_source.rs:25:5
+  --> $DIR/from_source.rs:26:5
    |
-25 |     source: io::Error,
+26 |     source: io::Error,
    |     ^^^^^^
 
 error: When deriving `From`, non-`#[from]` fields are not allowed
-  --> $DIR/from_source.rs:40:5
+  --> $DIR/from_source.rs:41:5
    |
-40 |     msg: String,
+41 |     msg: String,
    |     ^^^
 
 error: Cannot derive `From` on enum when two variants have same type for source error
-  --> $DIR/from_source.rs:49:19
+  --> $DIR/from_source.rs:50:19
    |
-49 |     Tuple(#[from] io::Error),
+50 |     Tuple(#[from] io::Error),
    |                   ^^^^^^^^^
 
 error: Cannot derive `From` on enum when two variants have same type for source error
-  --> $DIR/from_source.rs:59:19
+  --> $DIR/from_source.rs:60:19
    |
-59 |     Tuple(#[from] std::io::Error),
+60 |     Tuple(#[from] std::io::Error),
    |                   ^^^^^^^^^^^^^^
+
+error[E0119]: conflicting implementations of trait `std::convert::From<std::io::Error>` for type `EnumDuplicateFromType3`:
+  --> $DIR/from_source.rs:64:10
+   |
+64 | #[derive(Error, Debug)]
+   |          ^^^^^
+   |          |
+   |          first implementation here
+   |          conflicting implementation for `EnumDuplicateFromType3`

--- a/tests/ui/from_source.stderr
+++ b/tests/ui/from_source.stderr
@@ -21,3 +21,15 @@ error: When deriving `From`, non-`#[from]` fields are not allowed
    |
 40 |     msg: String,
    |     ^^^
+
+error: Cannot derive `From` on enum when two variants have same type for source error
+  --> $DIR/from_source.rs:49:19
+   |
+49 |     Tuple(#[from] io::Error),
+   |                   ^^^^^^^^^
+
+error: Cannot derive `From` on enum when two variants have same type for source error
+  --> $DIR/from_source.rs:59:19
+   |
+59 |     Tuple(#[from] std::io::Error),
+   |                   ^^^^^^^^^^^^^^

--- a/tests/ui/from_source.stderr
+++ b/tests/ui/from_source.stderr
@@ -1,0 +1,5 @@
+error: Only one `source` field allowed per struct or struct variant
+ --> $DIR/from_source.rs:5:8
+  |
+5 | struct BracedWithSourceDuplicate {
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/from_source.stderr
+++ b/tests/ui/from_source.stderr
@@ -3,3 +3,15 @@ error: Only one `source` field allowed per struct or struct variant
   |
 5 | struct BracedWithSourceDuplicate {
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Only one `#[from]` field allowed per struct or struct variant
+  --> $DIR/from_source.rs:13:8
+   |
+13 | struct BracedWithFromDuplicate1 {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: To derive From on this field, it must have a source (a field `source` or attr #[source])
+  --> $DIR/from_source.rs:26:5
+   |
+26 |     cause: io::Error,
+   |     ^^^^^

--- a/tests/ui/from_source.stderr
+++ b/tests/ui/from_source.stderr
@@ -21,9 +21,3 @@ error: When deriving `From`, non-`#[from]` fields are not allowed
    |
 40 |     msg: String,
    |     ^^^
-
-error: When deriving `From`, non-`#[from]` fields are not allowed
-  --> $DIR/from_source.rs:47:5
-   |
-47 |     msg: String,
-   |     ^^^

--- a/tests/ui/from_source.stderr
+++ b/tests/ui/from_source.stderr
@@ -1,17 +1,17 @@
-error: Only one `source` field allowed per struct or struct variant
- --> $DIR/from_source.rs:5:8
-  |
-5 | struct BracedWithSourceDuplicate {
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+error: Only one `source` field allowed per struct or struct variant (remember that `#[from]` implies `source`)
+  --> $DIR/from_source.rs:10:5
+   |
+10 |     cause: io::Error,
+   |     ^^^^^
 
 error: Only one `#[from]` field allowed per struct or struct variant
-  --> $DIR/from_source.rs:13:8
+  --> $DIR/from_source.rs:20:5
    |
-13 | struct BracedWithFromDuplicate1 {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+20 |     cause: io::Error,
+   |     ^^^^^
 
-error: To derive From on this field, it must have a source (a field `source` or attr #[source])
-  --> $DIR/from_source.rs:26:5
+error: Only one `source` field allowed per struct or struct variant (remember that `#[from]` implies `source`)
+  --> $DIR/from_source.rs:29:5
    |
-26 |     cause: io::Error,
+29 |     cause: io::Error,
    |     ^^^^^

--- a/tests/ui/from_source.stderr
+++ b/tests/ui/from_source.stderr
@@ -10,8 +10,20 @@ error: Only one `#[from]` field allowed per struct or struct variant
 20 |     cause: io::Error,
    |     ^^^^^
 
-error: Only one `source` field allowed per struct or struct variant (remember that `#[from]` implies `source`)
-  --> $DIR/from_source.rs:29:5
+error: When deriving `From`, non-`#[from]` fields are not allowed
+  --> $DIR/from_source.rs:25:5
    |
-29 |     cause: io::Error,
-   |     ^^^^^
+25 |     source: io::Error,
+   |     ^^^^^^
+
+error: When deriving `From`, non-`#[from]` fields are not allowed
+  --> $DIR/from_source.rs:40:5
+   |
+40 |     msg: String,
+   |     ^^^
+
+error: When deriving `From`, non-`#[from]` fields are not allowed
+  --> $DIR/from_source.rs:47:5
+   |
+47 |     msg: String,
+   |     ^^^


### PR DESCRIPTION
I've got the very basic functionality down, so I wanted to start the draft PR to begin to get feedback.

While implementing the `From` stuff, I want to make the changes to allow the implied `source` field, and fix the duplicate `source` issue since I have to deal with the source attribute anyways.

- [x] very basic derive `From` for struct and enum #2 
- [x] `trybuild`?
- [x] allow both source field and `#[source]` #4 
- [x] `source`, fix "first wins" to reject duplicates #6 
- [x] `#[from]` fix "first wins" to reject duplicates #6 (this will actually use use `source` to weed out duplicates, and the `from` and `source` must both map to same field).
- [x] `#[from]` implies `#[source]`
- [x] error if `#[from]` and `source` are on different fields (this is handled through a combination of `from` implying `source`, and disallowing `source` duplicates. So the actual error is for `source` duplicates.
- [x] error if `#[from]` and other fields exist in struct/variant (besides backtrace)
- [x] error if enum has multiple `#[from]` variants with same `source` error type (targeted error)
- [ ] docs

maybe:
- [ ] enum-level opt-in derive `From`, `#[error(from_source)]` for every variant that's `source`
- [ ] error on enum with opt-in `#[error(from_source)]` if has multiple `#[from]` variants with same `source` error type (general error)
- [ ] allow backtrace in derive `From`