### PR TITLE
Perform all validation up front

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -4,6 +4,8 @@ mod ast;
 mod attr;
 mod expand;
 mod fmt;
+mod prop;
+mod valid;
 
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -1,0 +1,9 @@
+use crate::ast::Enum;
+
+impl Enum<'_> {
+    pub(crate) fn has_display(&self) -> bool {
+        self.variants
+            .iter()
+            .any(|variant| variant.attrs.display.is_some())
+    }
+}

--- a/impl/src/valid.rs
+++ b/impl/src/valid.rs
@@ -1,0 +1,36 @@
+use crate::ast::{Enum, Input, Struct};
+use syn::{Error, Result};
+
+pub(crate) const CHECKED: &str = "checked in validation";
+
+impl Input<'_> {
+    pub(crate) fn validate(&self) -> Result<()> {
+        match self {
+            Input::Struct(input) => input.validate(),
+            Input::Enum(input) => input.validate(),
+        }
+    }
+}
+
+impl Struct<'_> {
+    fn validate(&self) -> Result<()> {
+        // nothing for now
+        Ok(())
+    }
+}
+
+impl Enum<'_> {
+    fn validate(&self) -> Result<()> {
+        if self.has_display() {
+            for variant in &self.variants {
+                if variant.attrs.display.is_none() {
+                    return Err(Error::new_spanned(
+                        variant.original,
+                        "missing #[error(\"...\")] display attribute",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
This reduces complexity by eliminating fallible code from expand.rs, especially as we add more validations later.