### PR TITLE
Assume #[source] attribute for fields named `source`

### DIFF
--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -44,20 +44,24 @@ impl Variant<'_> {
 }
 
 impl Field<'_> {
-    pub(crate) fn is_source(&self) -> bool {
-        self.attrs.source.is_some()
-    }
-
     fn is_backtrace(&self) -> bool {
         type_is_backtrace(self.ty)
     }
 }
 
 fn source_member<'a>(fields: &'a [Field]) -> Option<&'a Member> {
-    fields
-        .iter()
-        .find(|field| field.is_source())
-        .map(|field| &field.member)
+    for field in fields {
+        if field.attrs.source.is_some() {
+            return Some(&field.member);
+        }
+    }
+    for field in fields {
+        match &field.member {
+            Member::Named(ident) if ident == "source" => return Some(&field.member),
+            _ => {}
+        }
+    }
+    None
 }
 
 fn backtrace_member<'a>(fields: &'a [Field]) -> Option<&'a Member> {

--- a/tests/test_source.rs
+++ b/tests/test_source.rs
@@ -1,0 +1,34 @@
+use std::error::Error as _;
+use std::io;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("implicit source")]
+pub struct ImplicitSource {
+    source: io::Error,
+}
+
+#[derive(Error, Debug)]
+#[error("explicit source")]
+pub struct ExplicitSource {
+    source: String,
+    #[source]
+    io: io::Error,
+}
+
+#[test]
+fn test_implicit_source() {
+    let io = io::Error::new(io::ErrorKind::Other, "oh no!");
+    let error = ImplicitSource { source: io };
+    error.source().unwrap().downcast_ref::<io::Error>().unwrap();
+}
+
+#[test]
+fn test_explicit_source() {
+    let io = io::Error::new(io::ErrorKind::Other, "oh no!");
+    let error = ExplicitSource {
+        source: String::new(),
+        io,
+    };
+    error.source().unwrap().downcast_ref::<io::Error>().unwrap();
+}


### PR DESCRIPTION
Fixes #4.