### PR TITLE
display: avoid using `formatter`

### DIFF
--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -140,16 +140,16 @@ impl ToTokens for Display<'_> {
         if self.was_shorthand && fmt.value() == "{}" {
             let arg = args.clone().into_iter().nth(1).unwrap();
             tokens.extend(quote! {
-                std::fmt::Display::fmt(#arg, formatter)
+                std::fmt::Display::fmt(#arg, _thiserror_formatter)
             });
         } else if self.was_shorthand && fmt.value() == "{:?}" {
             let arg = args.clone().into_iter().nth(1).unwrap();
             tokens.extend(quote! {
-                std::fmt::Debug::fmt(#arg, formatter)
+                std::fmt::Debug::fmt(#arg, _thiserror_formatter)
             });
         } else {
             tokens.extend(quote! {
-                write!(formatter, #fmt #args)
+                write!(_thiserror_formatter, #fmt #args)
             });
         }
     }

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -80,7 +80,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         let pat = fields_pat(&input.fields);
         quote! {
             impl #impl_generics std::fmt::Display for #ty #ty_generics #where_clause {
-                fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                fn fmt(&self, _thiserror_formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                     #[allow(unused_variables)]
                     let Self #pat = self;
                     #display
@@ -230,7 +230,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         });
         Some(quote! {
             impl #impl_generics std::fmt::Display for #ty #ty_generics #where_clause {
-                fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                fn fmt(&self, _thiserror_formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                     #[allow(unused_variables)]
                     match #void_deref self {
                         #(#arms,)*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //!   }
 //!   #
 //!   # impl Display for MyError {
-//!   #     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+//!   #     fn fmt(&self, _thiserror_formatter: &mut fmt::Formatter) -> fmt::Result {
 //!   #         unimplemented!()
 //!   #     }
 //!   # }


### PR DESCRIPTION
This can collide with enum variant field names. Namespace with a
`_thiserror_` prefix to avoid such collisions.