### PR TITLE
Support referring to statics and consts from shorthand

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0.10"
+syn = "1.0.11"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
+syn = "1.0.10"

--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -53,14 +53,15 @@ impl<'a> Input<'a> {
 impl<'a> Struct<'a> {
     fn from_syn(node: &'a DeriveInput, data: &'a DataStruct) -> Result<Self> {
         let mut attrs = attr::get(&node.attrs)?;
+        let fields = Field::multiple_from_syn(&data.fields)?;
         if let Some(display) = &mut attrs.display {
-            display.expand_shorthand();
+            display.expand_shorthand(&fields);
         }
         Ok(Struct {
             attrs,
             ident: node.ident.clone(),
             generics: &node.generics,
-            fields: Field::multiple_from_syn(&data.fields)?,
+            fields,
         })
     }
 }
@@ -77,7 +78,7 @@ impl<'a> Enum<'a> {
                     *display = attrs.display.clone();
                 }
                 if let Some(display) = &mut variant.attrs.display {
-                    display.expand_shorthand();
+                    display.expand_shorthand(&variant.fields);
                 }
                 Ok(variant)
             })

--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -52,8 +52,12 @@ impl<'a> Input<'a> {
 
 impl<'a> Struct<'a> {
     fn from_syn(node: &'a DeriveInput, data: &'a DataStruct) -> Result<Self> {
+        let mut attrs = attr::get(&node.attrs)?;
+        if let Some(display) = &mut attrs.display {
+            display.expand_shorthand();
+        }
         Ok(Struct {
-            attrs: attr::get(&node.attrs)?,
+            attrs,
             ident: node.ident.clone(),
             generics: &node.generics,
             fields: Field::multiple_from_syn(&data.fields)?,
@@ -71,6 +75,9 @@ impl<'a> Enum<'a> {
                 let mut variant = Variant::from_syn(node)?;
                 if let display @ None = &mut variant.attrs.display {
                     *display = attrs.display.clone();
+                }
+                if let Some(display) = &mut variant.attrs.display {
+                    display.expand_shorthand();
                 }
                 Ok(variant)
             })

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -70,15 +70,13 @@ pub fn get(input: &[Attribute]) -> Result<Attrs> {
 
 fn parse_display(attr: &Attribute) -> Result<Display> {
     attr.parse_args_with(|input: ParseStream| {
-        let mut display = Display {
+        Ok(Display {
             original: attr,
             fmt: input.parse()?,
             args: parse_token_expr(input, false)?,
             was_shorthand: false,
             has_bonus_display: false,
-        };
-        display.expand_shorthand();
-        Ok(display)
+        })
     })
 }
 

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -47,8 +47,8 @@ impl Display<'_> {
                 _ => return,
             };
             let ident = match &member {
-                Member::Unnamed(member) => format_ident!("_{}", member.index, span = span),
-                Member::Named(member) => member.clone(),
+                Member::Unnamed(index) => format_ident!("_{}", index),
+                Member::Named(ident) => ident.clone(),
             };
             args.extend(quote_spanned!(span=> , #ident));
             if read.starts_with('}') && fields.contains(&member) {

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -1,3 +1,4 @@
+use crate::ast::Field;
 use crate::attr::Display;
 use proc_macro2::TokenStream;
 use quote::quote_spanned;
@@ -5,7 +6,7 @@ use syn::{Ident, LitStr};
 
 impl Display<'_> {
     // Transform `"error {var}"` to `"error {}", var`.
-    pub fn expand_shorthand(&mut self) {
+    pub fn expand_shorthand(&mut self, _fields: &[Field]) {
         if !self.args.is_empty() {
             return;
         }

--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -32,6 +32,15 @@ enum EnumError {
 }
 
 #[derive(Error, Debug)]
+#[error("{MSG}: {id:?} (code {CODE:?})")]
+struct WithConstant {
+    id: &'static str,
+}
+
+const MSG: &str = "failed to do";
+const CODE: usize = 9;
+
+#[derive(Error, Debug)]
 #[error("{0}")]
 enum Inherit {
     Unit(UnitError),
@@ -73,6 +82,7 @@ fn test_display() {
     assert("braced error: 0", EnumError::Braced { id: 0 });
     assert("tuple error: 0", EnumError::Tuple(0));
     assert("unit error", EnumError::Unit);
+    assert("failed to do: \"\" (code 9)", WithConstant { id: "" });
     assert("unit error", Inherit::Unit(UnitError));
     assert("other error", Inherit::Other(UnitError));
     assert("fn main() {}", Braces);


### PR DESCRIPTION
a.k.a. `{ident}` for identifiers that are something other than fields of the current struct or variant.

```rust
const LIMIT: usize = 999;

#[derive(Error, Debug)]
#[error("value is too big: {val}, must be < {LIMIT}")]
struct Demo {
    val: usize,
}
```