### PR TITLE
Add transparent attribute for delegating Error impl to one field

### DIFF
--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -79,6 +79,8 @@ impl<'a> Enum<'a> {
                 }
                 if let Some(display) = &mut variant.attrs.display {
                     display.expand_shorthand(&variant.fields);
+                } else if variant.attrs.transparent.is_none() {
+                    variant.attrs.transparent = attrs.transparent;
                 }
                 Ok(variant)
             })

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -19,7 +19,7 @@ impl Enum<'_> {
     pub(crate) fn has_source(&self) -> bool {
         self.variants
             .iter()
-            .any(|variant| variant.source_field().is_some())
+            .any(|variant| variant.source_field().is_some() || variant.attrs.transparent.is_some())
     }
 
     pub(crate) fn has_backtrace(&self) -> bool {
@@ -30,10 +30,15 @@ impl Enum<'_> {
 
     pub(crate) fn has_display(&self) -> bool {
         self.attrs.display.is_some()
+            || self.attrs.transparent.is_some()
             || self
                 .variants
                 .iter()
                 .any(|variant| variant.attrs.display.is_some())
+            || self
+                .variants
+                .iter()
+                .all(|variant| variant.attrs.transparent.is_some())
     }
 }
 

--- a/impl/src/valid.rs
+++ b/impl/src/valid.rs
@@ -4,8 +4,6 @@ use quote::ToTokens;
 use std::collections::BTreeSet as Set;
 use syn::{Error, Member, Result};
 
-pub(crate) const CHECKED: &str = "checked in validation";
-
 impl Input<'_> {
     pub(crate) fn validate(&self) -> Result<()> {
         match self {

--- a/tests/test_transparent.rs
+++ b/tests/test_transparent.rs
@@ -1,0 +1,57 @@
+use anyhow::anyhow;
+use std::error::Error as _;
+use std::io;
+use thiserror::Error;
+
+#[test]
+fn test_transparent_struct() {
+    #[derive(Error, Debug)]
+    #[error(transparent)]
+    struct Error(ErrorKind);
+
+    #[derive(Error, Debug)]
+    enum ErrorKind {
+        #[error("E0")]
+        E0,
+        #[error("E1")]
+        E1(#[from] io::Error),
+    }
+
+    let error = Error(ErrorKind::E0);
+    assert_eq!("E0", error.to_string());
+    assert!(error.source().is_none());
+
+    let io = io::Error::new(io::ErrorKind::Other, "oh no!");
+    let error = Error(ErrorKind::from(io));
+    assert_eq!("E1", error.to_string());
+    error.source().unwrap().downcast_ref::<io::Error>().unwrap();
+}
+
+#[test]
+fn test_transparent_enum() {
+    #[derive(Error, Debug)]
+    enum Error {
+        #[error("this failed")]
+        This,
+        #[error(transparent)]
+        Other(anyhow::Error),
+    }
+
+    let error = Error::This;
+    assert_eq!("this failed", error.to_string());
+
+    let error = Error::Other(anyhow!("inner").context("outer"));
+    assert_eq!("outer", error.to_string());
+    assert_eq!("inner", error.source().unwrap().to_string());
+}
+
+#[test]
+fn test_anyhow() {
+    #[derive(Error, Debug)]
+    #[error(transparent)]
+    struct Any(#[from] anyhow::Error);
+
+    let error = Any::from(anyhow!("inner").context("outer"));
+    assert_eq!("outer", error.to_string());
+    assert_eq!("inner", error.source().unwrap().to_string());
+}


### PR DESCRIPTION
This is useful for hiding error variants from a library's public error type:

```rust
#[derive(Error, Debug)]
#[error(transparent)]  // source and Display delegate to ErrorKind
pub struct Error(ErrorKind);

#[derive(Error, Debug)]
/*private*/ enum ErrorKind {
    #[error("...")]
    E0,
    #[error("...")]
    E1(#[source] io::Error),
}
```

And also for enums that need an "anything else" variant; such variants tend not to have their own Display message but just forward through to the underlying error's Display and source:

```rust
#[derive(Error, Debug)]
pub enum MyError {
    ...

    #[error(transparent)]
    Other(#[from] anyhow::Error),  // source and Display delegate to anyhow::Error
}
```

Closes #40.