### PR TITLE
Support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,17 @@ readme = "README.md"
 travis-ci = { repository = "dtolnay/thiserror" }
 
 [dependencies]
-thiserror-impl = { version = "=1.0.11", path = "impl" }
+thiserror-impl = { version = "=1.0.11", path = "impl", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"
 ref-cast = "1.0"
 rustversion = "1.0"
 trybuild = { version = "1.0.19", features = ["diff"] }
+
+[features]
+default = ["std"]
+std = ["thiserror-impl/std"]
 
 [workspace]
 members = ["impl"]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -17,3 +17,7 @@ travis-ci = { repository = "dtolnay/thiserror" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0.11"
+
+[features]
+default = ["std"]
+std = []

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -1,11 +1,14 @@
 use crate::ast::{Enum, Field, Struct, Variant};
-use syn::{Member, Type};
+#[cfg(feature = "std")]
+use syn::Member;
+use syn::Type;
 
 impl Struct<'_> {
     pub(crate) fn from_field(&self) -> Option<&Field> {
         from_field(&self.fields)
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn source_field(&self) -> Option<&Field> {
         source_field(&self.fields)
     }
@@ -16,12 +19,14 @@ impl Struct<'_> {
 }
 
 impl Enum<'_> {
+    #[cfg(feature = "std")]
     pub(crate) fn has_source(&self) -> bool {
         self.variants
             .iter()
             .any(|variant| variant.source_field().is_some() || variant.attrs.transparent.is_some())
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn has_backtrace(&self) -> bool {
         self.variants
             .iter()
@@ -47,6 +52,7 @@ impl Variant<'_> {
         from_field(&self.fields)
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn source_field(&self) -> Option<&Field> {
         source_field(&self.fields)
     }
@@ -71,6 +77,7 @@ fn from_field<'a, 'b>(fields: &'a [Field<'b>]) -> Option<&'a Field<'b>> {
     None
 }
 
+#[cfg(feature = "std")]
 fn source_field<'a, 'b>(fields: &'a [Field<'b>]) -> Option<&'a Field<'b>> {
     for field in fields {
         if field.attrs.from.is_some() || field.attrs.source.is_some() {

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+#[cfg(feature = "std")]
 use std::path::{self, Path, PathBuf};
 
 pub trait DisplayAsDisplay {
@@ -11,16 +12,19 @@ impl<T: Display> DisplayAsDisplay for &T {
     }
 }
 
+#[cfg(feature = "std")]
 pub trait PathAsDisplay {
     fn as_display(&self) -> path::Display<'_>;
 }
 
+#[cfg(feature = "std")]
 impl PathAsDisplay for Path {
     fn as_display(&self) -> path::Display<'_> {
         self.display()
     }
 }
 
+#[cfg(feature = "std")]
 impl PathAsDisplay for PathBuf {
     fn as_display(&self) -> path::Display<'_> {
         self.display()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,20 @@
 //!
 //!   [`anyhow`]: https://github.com/dtolnay/anyhow
 
+// always enabled to force devs to add imports for things like Vec and String, even when working
+// with std
+#![no_std]
+
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc as std;
+#[cfg(feature = "std")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate std;
+
+#[cfg(feature = "std")]
 mod aserror;
 mod display;
 
@@ -184,6 +198,9 @@ pub use thiserror_impl::*;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
+    #[cfg(feature = "std")]
     pub use crate::aserror::AsDynError;
-    pub use crate::display::{DisplayAsDisplay, PathAsDisplay};
+    pub use crate::display::DisplayAsDisplay;
+    #[cfg(feature = "std")]
+    pub use crate::display::PathAsDisplay;
 }


### PR DESCRIPTION
This PR adds an "std" feature that is enabled by default, which allows users to disable the Error trait when needed, while keeping the Display and From traits.

This is useful for libraries that would like to support no_std while using thiserror to reduce boilerplate. For example: https://github.com/bytecodealliance/cranelift/issues/1261#issuecomment-589475011