### PR TITLE
Improve span of missing Display impl error

### DIFF
--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -10,6 +10,7 @@ pub enum Input<'a> {
 }
 
 pub struct Struct<'a> {
+    pub original: &'a DeriveInput,
     pub attrs: Attrs<'a>,
     pub ident: Ident,
     pub generics: &'a Generics,
@@ -17,6 +18,7 @@ pub struct Struct<'a> {
 }
 
 pub struct Enum<'a> {
+    pub original: &'a DeriveInput,
     pub attrs: Attrs<'a>,
     pub ident: Ident,
     pub generics: &'a Generics,
@@ -58,6 +60,7 @@ impl<'a> Struct<'a> {
             display.expand_shorthand(&fields);
         }
         Ok(Struct {
+            original: node,
             attrs,
             ident: node.ident.clone(),
             generics: &node.generics,
@@ -86,6 +89,7 @@ impl<'a> Enum<'a> {
             })
             .collect::<Result<_>>()?;
         Ok(Enum {
+            original: node,
             attrs,
             ident: node.ident.clone(),
             generics: &node.generics,

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -1,9 +1,8 @@
 error[E0277]: `MyError` doesn't implement `std::fmt::Display`
- --> $DIR/missing-display.rs:3:10
+ --> $DIR/missing-display.rs:4:1
   |
-3 | #[derive(Error, Debug)]
-  |          ^^^^^ `MyError` cannot be formatted with the default formatter
+4 | pub enum MyError {
+  | ^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `MyError`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Before:

```console
error[E0277]: `MyError` doesn't implement `std::fmt::Display`
 --> $DIR/missing-display.rs:3:10
  |
3 | #[derive(Error, Debug)]
  |          ^^^^^ `MyError` cannot be formatted with the default formatter
  |
  = help: the trait `std::fmt::Display` is not implemented for `MyError`
```

After:

```console
error[E0277]: `MyError` doesn't implement `std::fmt::Display`
 --> $DIR/missing-display.rs:4:1
  |
4 | pub enum MyError {
  | ^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
  |
  = help: the trait `std::fmt::Display` is not implemented for `MyError`
```

Closes #75.