### PR TITLE
Suppress unused_qualifications lint

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -113,6 +113,7 @@ fn impl_struct(input: Struct) -> TokenStream {
     };
     let display_impl = display_body.map(|body| {
         quote! {
+            #[allow(unused_qualifications)]
             impl #impl_generics std::fmt::Display for #ty #ty_generics #where_clause {
                 #[allow(clippy::used_underscore_binding)]
                 fn fmt(&self, __formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -127,6 +128,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         let from = from_field.ty;
         let body = from_initializer(from_field, backtrace_field);
         quote! {
+            #[allow(unused_qualifications)]
             impl #impl_generics std::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
                 fn from(source: #from) -> Self {
@@ -139,6 +141,7 @@ fn impl_struct(input: Struct) -> TokenStream {
     let error_trait = spanned_error_trait(input.original);
 
     quote! {
+        #[allow(unused_qualifications)]
         impl #impl_generics #error_trait for #ty #ty_generics #where_clause {
             #source_method
             #backtrace_method
@@ -294,6 +297,7 @@ fn impl_enum(input: Enum) -> TokenStream {
             }
         });
         Some(quote! {
+            #[allow(unused_qualifications)]
             impl #impl_generics std::fmt::Display for #ty #ty_generics #where_clause {
                 fn fmt(&self, __formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                     #use_as_display
@@ -315,6 +319,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         let from = from_field.ty;
         let body = from_initializer(from_field, backtrace_field);
         Some(quote! {
+            #[allow(unused_qualifications)]
             impl #impl_generics std::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
                 fn from(source: #from) -> Self {
@@ -327,6 +332,7 @@ fn impl_enum(input: Enum) -> TokenStream {
     let error_trait = spanned_error_trait(input.original);
 
     quote! {
+        #[allow(unused_qualifications)]
         impl #impl_generics #error_trait for #ty #ty_generics #where_clause {
             #source_method
             #backtrace_method

--- a/tests/test_lints.rs
+++ b/tests/test_lints.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+pub use std::error::Error;
+
+#[test]
+fn test_unused_qualifications() {
+    #![deny(unused_qualifications)]
+
+    // Expansion of derive(Error) macro can't know whether something like
+    // std::error::Error is already imported in the caller's scope so it must
+    // suppress unused_qualifications.
+
+    #[derive(Debug, Error)]
+    #[error("...")]
+    pub struct MyError;
+}


### PR DESCRIPTION
Expansion of derive(Error) macro can't know whether something like std::error::Error is already imported in the caller's scope so it must emit qualified paths and suppress unused_qualifications.

Fixes #91.