### PR TITLE
Forward the backtrace when a source is specified for enum variants

### DIFF
--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -8,6 +8,8 @@ impl Struct<'_> {
 
     pub(crate) fn source_field(&self) -> Option<&Field> {
         source_field(&self.fields)
+            // If it is transparent, it has only one fields and is considered as the source
+            .or_else(|| self.attrs.transparent.map(|_| &self.fields[0]))
     }
 
     pub(crate) fn backtrace_field(&self) -> Option<&Field> {
@@ -49,6 +51,8 @@ impl Variant<'_> {
 
     pub(crate) fn source_field(&self) -> Option<&Field> {
         source_field(&self.fields)
+            // If it is transparent, it has only one fields and is considered as the source
+            .or_else(|| self.attrs.transparent.map(|_| &self.fields[0]))
     }
 
     pub(crate) fn backtrace_field(&self) -> Option<&Field> {

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -25,7 +25,7 @@ impl Enum<'_> {
     pub(crate) fn has_backtrace(&self) -> bool {
         self.variants
             .iter()
-            .any(|variant| variant.backtrace_field().is_some())
+            .any(|variant| variant.backtrace_field().is_some() || variant.source_field().is_some())
     }
 
     pub(crate) fn has_display(&self) -> bool {


### PR DESCRIPTION
Hi, I ran into an issue while using thiserror.

Let's consider this code:

```rust
/// This type provide a backtrace. The error derive will implement the backtrace method appropriately.
#[derive(Debug, Error)]
struct CustomError {
  message: String,
  backtrace: Backtrace,
}

/// This type encapsulate the previous error.
#[derive(Debug, Error)]
enum AggregateError {
  #[error(transparent)]
  Custom(#[from] CustomError)
}

/// A failing function
fn failing() -> Result<(), AggregateError> {
  /// The `?` convert the CustomError to an AggregateError thanks to the error derive.
  /// The backtrace of the CustomError will start here
  /// But, the converted AggregateError won't have a backtrace. (Implementation returns None in that case: no backtrace field in variant)
  Err(CustomError { message: "Failing".to_string(), backtrace: Bactrace::capture() })?;
  Ok(())  
}

fn middle() -> Result<(), anyhow::Error> {
   /// When converting to anyhow::Error, the backtrace will be captured, so it will start here
   failing()?;
  Ok(())
}

fn main() {
  // Running the function and failing.
  // The backtrace will start at `middle` from the conversion to anyhow::Error,
  // although, I would expect it to start from `failing`
  middle().unwrap();
}
```

The way I "fixed" this is by forwarding the backtrace if a source is defined in an enum's variant.
To be consistent it should as well update the implementation for structs.

But what are your thoughts about this? Is there a way to "forward backtrace from a source" with the derive macro?