### PR TITLE
Generalize backtrace capture to From<Backtrace> types, including Arc<Backtrace>

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -367,7 +367,7 @@ fn from_initializer(from_field: &Field, backtrace_field: Option<&Field>) -> Toke
             }
         } else {
             quote! {
-                #backtrace_member: std::backtrace::Backtrace::capture(),
+                #backtrace_member: std::convert::From::from(std::backtrace::Backtrace::capture()),
             }
         }
     });

--- a/tests/test_backtrace.rs
+++ b/tests/test_backtrace.rs
@@ -59,6 +59,15 @@ pub mod structs {
         backtrace: Option<Backtrace>,
     }
 
+    #[derive(Error, Debug)]
+    #[error("...")]
+    pub struct ArcBacktraceFrom {
+        #[from]
+        source: Inner,
+        #[backtrace]
+        backtrace: Arc<Backtrace>,
+    }
+
     #[test]
     fn test_backtrace() {
         let error = PlainBacktrace {
@@ -85,6 +94,9 @@ pub mod structs {
         assert!(error.backtrace().is_some());
 
         let error = OptBacktraceFrom::from(Inner);
+        assert!(error.backtrace().is_some());
+
+        let error = ArcBacktraceFrom::from(Inner);
         assert!(error.backtrace().is_some());
     }
 }
@@ -152,6 +164,17 @@ pub mod enums {
         },
     }
 
+    #[derive(Error, Debug)]
+    pub enum ArcBacktraceFrom {
+        #[error("...")]
+        Test {
+            #[from]
+            source: Inner,
+            #[backtrace]
+            backtrace: Arc<Backtrace>,
+        },
+    }
+
     #[test]
     fn test_backtrace() {
         let error = PlainBacktrace::Test {
@@ -178,6 +201,9 @@ pub mod enums {
         assert!(error.backtrace().is_some());
 
         let error = OptBacktraceFrom::from(Inner);
+        assert!(error.backtrace().is_some());
+
+        let error = ArcBacktraceFrom::from(Inner);
         assert!(error.backtrace().is_some());
     }
 }


### PR DESCRIPTION
Arc\<Backtrace\> is important because it enables error types that implement Clone, since Backtrace itself cannot be cloned.