### PR TITLE
Bound generic for Error and Display impls

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -296,9 +296,16 @@ fn impl_enum(input: Enum) -> TokenStream {
                 #ty::#ident #pat => #display
             }
         });
+        let display_impl_generics = {
+            let type_params = input.generics.type_params();
+
+            quote! {
+                <#(#type_params: std::fmt::Display),*>
+            }
+        };
         Some(quote! {
             #[allow(unused_qualifications)]
-            impl #impl_generics std::fmt::Display for #ty #ty_generics #where_clause {
+            impl #display_impl_generics std::fmt::Display for #ty #ty_generics #where_clause {
                 fn fmt(&self, __formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                     #use_as_display
                     #[allow(unused_variables, deprecated, clippy::used_underscore_binding)]
@@ -331,6 +338,14 @@ fn impl_enum(input: Enum) -> TokenStream {
 
     let error_trait = spanned_error_trait(input.original);
 
+    let impl_generics = {
+        let type_params = input.generics.type_params();
+
+        quote! {
+            <#(#type_params: std::fmt::Debug + std::fmt::Display),*>
+        }
+    };
+    
     quote! {
         #[allow(unused_qualifications)]
         impl #impl_generics #error_trait for #ty #ty_generics #where_clause {

--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -206,6 +206,20 @@ fn test_field() {
 }
 
 #[test]
+fn test_generic() {
+    #[derive(Error, Debug)]
+    enum Error<T> {
+        #[error("variant")]
+        Variant,
+        #[error("{0}")]
+        Generic(T),
+    }
+
+    assert("variant", Error::<&str>::Variant);
+    assert("err", Error::Generic("err"));
+}
+
+#[test]
 fn test_macro_rules() {
     // Regression test for https://github.com/dtolnay/thiserror/issues/86
 

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -49,6 +49,18 @@ enum EnumError {
     Unit,
 }
 
+#[derive(Error, Debug)]
+enum WithGeneric<T> {
+    Variant,
+    Generic(T),
+}
+
+impl<T: Display> Display for WithGeneric<T> {
+    fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
+        unimplemented!()
+    }
+}
+
 unimplemented_display!(BracedError);
 unimplemented_display!(TupleError);
 unimplemented_display!(UnitError);


### PR DESCRIPTION
Allows for functionality similar to what is described in #79 although without a `#[from]`.

I have not used syn very extensively so there might be a better way to build the `impl_generics`.