### PR TITLE
Fix keyword as fmt argument

### DIFF
--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -102,7 +102,7 @@ fn explicit_named_args(input: ParseStream) -> Result<Set<Ident>> {
     while !input.is_empty() {
         if input.peek(Token![,]) && input.peek2(Ident::peek_any) && input.peek3(Token![=]) {
             input.parse::<Token![,]>()?;
-            let ident: Ident = input.parse()?;
+            let ident = input.call(Ident::parse_any)?;
             input.parse::<Token![=]>()?;
             named_args.insert(ident);
         } else {

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -143,5 +143,5 @@ fn take_ident(read: &mut &str) -> Ident {
             }
         }
     }
-    syn::parse_str(&ident).unwrap()
+    Ident::parse_any.parse_str(&ident).unwrap()
 }

--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -263,3 +263,12 @@ fn test_raw_conflict() {
 
     assert("braced raw error: T, U", Error::Braced { r#func: "T" });
 }
+
+#[test]
+fn test_keyword() {
+    #[derive(Error, Debug)]
+    #[error("error: {type}", type = 1)]
+    struct Error;
+
+    assert("error: 1", Error);
+}


### PR DESCRIPTION
The standard library's format macros allow keyword named argument, as in `format_args!("{type}", type = 1)`. These were previously crashing thiserror.

```console
error: proc-macro derive panicked
   --> tests/test_display.rs:269:14
    |
269 |     #[derive(Error, Debug)]
    |              ^^^^^
    |
    = help: message: called `Result::unwrap()` on an `Err` value: Error("expected identifier")
```