### PR TITLE
Use i32::MAX instead of i32::max_value()

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pub enum DataStoreError {
   ```rust
   #[derive(Error, Debug)]
   pub enum Error {
-      #[error("invalid rdo_lookahead_frames {0} (expected < {})", i32::max_value())]
+      #[error("invalid rdo_lookahead_frames {0} (expected < {})", i32::MAX)]
       InvalidLookahead(u32),
   }
   ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 //!   #
 //!   #[derive(Error, Debug)]
 //!   pub enum Error {
-//!       #[error("invalid rdo_lookahead_frames {0} (expected < {})", i32::max_value())]
+//!       #[error("invalid rdo_lookahead_frames {0} (expected < {})", i32::MAX)]
 //!       InvalidLookahead(u32),
 //!   }
 //!   ```


### PR DESCRIPTION
Tiny change. But just using the newer, simpler and nicer constants.