### PR TITLE
Allow `backtrace::Backtrace` on errors, with a feature to use `std::backtrace::Backtrace` instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         rust: [beta, stable, 1.36.0]
         include:
           - rust: nightly
-            rustflags: --cfg thiserror_nightly_testing
+            rustflags: --cfg 'featue="stdbacktrace"'
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,16 @@ readme = "README.md"
 
 [dependencies]
 thiserror-impl = { version = "=1.0.24", path = "impl" }
+backtrace = "^0.3"
 
 [dev-dependencies]
 anyhow = "1.0"
 ref-cast = "1.0"
 rustversion = "1.0"
 trybuild = { version = "1.0.19", features = ["diff"] }
+
+[features]
+stdbacktrace = ["thiserror-impl/stdbacktrace"]
 
 [workspace]
 members = ["impl"]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -14,6 +14,10 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0.45"
+backtrace = "^0.3"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+stdbacktrace = []

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -9,6 +9,7 @@
     clippy::single_match_else,
     clippy::too_many_lines
 )]
+#![cfg_attr(feature = "stdbacktrace", feature(backtrace))]
 
 extern crate proc_macro;
 

--- a/src/backtrace.rs
+++ b/src/backtrace.rs
@@ -1,0 +1,11 @@
+use std::error::Error;
+
+pub trait Backtrace: Error {
+    fn backtrace(&self) -> Option<&backtrace::Backtrace>;
+}
+
+impl Backtrace for &(dyn Backtrace) {
+    fn backtrace(&self) -> Option<&backtrace::Backtrace> {
+        Backtrace::backtrace(*self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,11 +186,17 @@
 //!   [`anyhow`]: https://github.com/dtolnay/anyhow
 
 #![allow(clippy::module_name_repetitions)]
+#![cfg_attr(feature = "stdbacktrace", feature(backtrace))]
 
 mod aserror;
+#[cfg(not(feature = "stdbacktrace"))]
+mod backtrace;
 mod display;
 
 pub use thiserror_impl::*;
+
+#[cfg(not(feature = "stdbacktrace"))]
+pub use crate::backtrace::Backtrace;
 
 // Not public API.
 #[doc(hidden)]

--- a/tests/test_backtrace.rs
+++ b/tests/test_backtrace.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(thiserror_nightly_testing, feature(backtrace))]
+#![cfg_attr(feature = "stdbacktrace", feature(backtrace))]
 
 use thiserror::Error;
 
@@ -6,10 +6,23 @@ use thiserror::Error;
 #[error("...")]
 pub struct Inner;
 
-#[cfg(thiserror_nightly_testing)]
+#[cfg(feature = "stdbacktrace")]
+fn backtrace() -> std::backtrace::Backtrace {
+    std::backtrace::Backtrace::capture()
+}
+
+#[cfg(not(feature = "stdbacktrace"))]
+fn backtrace() -> backtrace::Backtrace {
+    backtrace::Backtrace::new()
+}
+
 pub mod structs {
-    use super::Inner;
+    use super::{backtrace, Inner};
+    #[cfg(not(feature = "stdbacktrace"))]
+    use backtrace::Backtrace;
+    #[cfg(feature = "stdbacktrace")]
     use std::backtrace::Backtrace;
+    #[cfg(feature = "stdbacktrace")]
     use std::error::Error;
     use std::sync::Arc;
     use thiserror::Error;
@@ -69,24 +82,28 @@ pub mod structs {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "stdbacktrace"), allow(unstable_name_collisions))]
     fn test_backtrace() {
+        #[cfg(not(feature = "stdbacktrace"))]
+        use thiserror::Backtrace as _;
+
         let error = PlainBacktrace {
-            backtrace: Backtrace::capture(),
+            backtrace: backtrace(),
         };
         assert!(error.backtrace().is_some());
 
         let error = ExplicitBacktrace {
-            backtrace: Backtrace::capture(),
+            backtrace: backtrace(),
         };
         assert!(error.backtrace().is_some());
 
         let error = OptBacktrace {
-            backtrace: Some(Backtrace::capture()),
+            backtrace: Some(backtrace()),
         };
         assert!(error.backtrace().is_some());
 
         let error = ArcBacktrace {
-            backtrace: Arc::new(Backtrace::capture()),
+            backtrace: Arc::new(backtrace()),
         };
         assert!(error.backtrace().is_some());
 
@@ -101,10 +118,13 @@ pub mod structs {
     }
 }
 
-#[cfg(thiserror_nightly_testing)]
 pub mod enums {
-    use super::Inner;
+    use super::{backtrace, Inner};
+    #[cfg(not(feature = "stdbacktrace"))]
+    use backtrace::Backtrace;
+    #[cfg(feature = "stdbacktrace")]
     use std::backtrace::Backtrace;
+    #[cfg(feature = "stdbacktrace")]
     use std::error::Error;
     use std::sync::Arc;
     use thiserror::Error;
@@ -176,24 +196,28 @@ pub mod enums {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "stdbacktrace"), allow(unstable_name_collisions))]
     fn test_backtrace() {
+        #[cfg(not(feature = "stdbacktrace"))]
+        use thiserror::Backtrace as _;
+
         let error = PlainBacktrace::Test {
-            backtrace: Backtrace::capture(),
+            backtrace: backtrace(),
         };
         assert!(error.backtrace().is_some());
 
         let error = ExplicitBacktrace::Test {
-            backtrace: Backtrace::capture(),
+            backtrace: backtrace(),
         };
         assert!(error.backtrace().is_some());
 
         let error = OptBacktrace::Test {
-            backtrace: Some(Backtrace::capture()),
+            backtrace: Some(backtrace()),
         };
         assert!(error.backtrace().is_some());
 
         let error = ArcBacktrace::Test {
-            backtrace: Arc::new(Backtrace::capture()),
+            backtrace: Arc::new(backtrace()),
         };
         assert!(error.backtrace().is_some());
 
@@ -207,7 +231,3 @@ pub mod enums {
         assert!(error.backtrace().is_some());
     }
 }
-
-#[test]
-#[cfg_attr(not(thiserror_nightly_testing), ignore)]
-fn test_backtrace() {}

--- a/tests/test_option.rs
+++ b/tests/test_option.rs
@@ -1,8 +1,10 @@
-#![cfg_attr(thiserror_nightly_testing, feature(backtrace))]
+#![cfg_attr(feature = "stdbacktrace", feature(backtrace))]
 #![deny(clippy::all, clippy::pedantic)]
 
-#[cfg(thiserror_nightly_testing)]
 pub mod structs {
+    #[cfg(not(feature = "stdbacktrace"))]
+    use backtrace::Backtrace;
+    #[cfg(feature = "stdbacktrace")]
     use std::backtrace::Backtrace;
     use thiserror::Error;
 
@@ -46,8 +48,10 @@ pub mod structs {
     }
 }
 
-#[cfg(thiserror_nightly_testing)]
 pub mod enums {
+    #[cfg(not(feature = "stdbacktrace"))]
+    use backtrace::Backtrace;
+    #[cfg(feature = "stdbacktrace")]
     use std::backtrace::Backtrace;
     use thiserror::Error;
 
@@ -102,5 +106,4 @@ pub mod enums {
 }
 
 #[test]
-#[cfg_attr(not(thiserror_nightly_testing), ignore)]
 fn test_option() {}


### PR DESCRIPTION
This allows errors to have a [`backtrace::Backtrace`](https://docs.rs/backtrace/*/backtrace/struct.Backtrace.html) on them, and adds a feature to allow use of [`std::backtrace::Backtrace`](https://doc.rust-lang.org/std/backtrace/struct.Backtrace.html) instead.

The tests all pass on stable and nightly (including nightly with the new `stdbacktrace` feature enabled). Clippy is happy.

This would close #130.