### PR TITLE
Add `bound` attribute for generics support

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -128,7 +128,11 @@ fn impl_struct(input: Struct) -> TokenStream {
 
     let display_impl = display_body.map(|body| {
         quote! {
-            #[allow(unused_qualifications)]
+            #[allow(
+                unused_qualifications,
+                // Since we don't merge bounds that cover the same type, suppress this issue
+                clippy::type_repetition_in_bounds,
+            )]
             impl #impl_generics std::fmt::Display for #ty #ty_generics #where_clause {
                 #[allow(
                     // Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
@@ -147,7 +151,11 @@ fn impl_struct(input: Struct) -> TokenStream {
         let from = from_field.ty;
         let body = from_initializer(from_field, backtrace_field);
         quote! {
-            #[allow(unused_qualifications)]
+            #[allow(
+                unused_qualifications,
+                // Since we don't merge bounds that cover the same type, suppress this issue
+                clippy::type_repetition_in_bounds,
+            )]
             impl #impl_generics std::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
                 fn from(source: #from) -> Self {
@@ -159,7 +167,11 @@ fn impl_struct(input: Struct) -> TokenStream {
 
     let error_trait = spanned_error_trait(input.original);
     quote! {
-        #[allow(unused_qualifications)]
+        #[allow(
+            unused_qualifications,
+            // Since we don't merge bounds that cover the same type, suppress this issue
+            clippy::type_repetition_in_bounds,
+        )]
         impl #impl_generics #error_trait for #ty #ty_generics #where_clause {
             #source_method
             #backtrace_method
@@ -329,7 +341,11 @@ fn impl_enum(input: Enum) -> TokenStream {
             }
         });
         Some(quote! {
-            #[allow(unused_qualifications)]
+            #[allow(
+                unused_qualifications,
+                // Since we don't merge bounds that cover the same type, suppress this issue
+                clippy::type_repetition_in_bounds,
+            )]
             impl #impl_generics std::fmt::Display for #ty #ty_generics #where_clause {
                 fn fmt(&self, __formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                     #use_as_display
@@ -357,7 +373,11 @@ fn impl_enum(input: Enum) -> TokenStream {
         let from = from_field.ty;
         let body = from_initializer(from_field, backtrace_field);
         Some(quote! {
-            #[allow(unused_qualifications)]
+            #[allow(
+                unused_qualifications,
+                // Since we don't merge bounds that cover the same type, suppress this issue
+                clippy::type_repetition_in_bounds,
+            )]
             impl #impl_generics std::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
                 fn from(source: #from) -> Self {
@@ -369,7 +389,11 @@ fn impl_enum(input: Enum) -> TokenStream {
 
     let error_trait = spanned_error_trait(input.original);
     quote! {
-        #[allow(unused_qualifications)]
+        #[allow(
+            unused_qualifications,
+            // Since we don't merge bounds that cover the same type, suppress this issue
+            clippy::type_repetition_in_bounds,
+        )]
         impl #impl_generics #error_trait for #ty #ty_generics #where_clause {
             #source_method
             #backtrace_method

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -487,8 +487,8 @@ fn apply_type_bounds<'a, TTypeParams: std::iter::Iterator<Item = &'a syn::TypePa
         return Vec::new();
     }
     type_params
-        .map(move |p| {
-            let predicate = quote! { #p: #bounds };
+        .map(move |syn::TypeParam { ident: tparam, .. }| {
+            let predicate = quote! { #tparam: #bounds };
             syn::parse2::<syn::WherePredicate>(predicate)
                 .expect("quasiquote must create predicate bounds")
         })

--- a/impl/src/valid.rs
+++ b/impl/src/valid.rs
@@ -38,7 +38,7 @@ impl Struct<'_> {
             if self.generics.params.is_empty() {
                 return Err(Error::new_spanned(
                     bound_span,
-                    "#[error(bound = ...)] requires generics to apply bounds against",
+                    "#[error(bound = ...)] requires at least one generic type parameter",
                 ));
             }
         }

--- a/impl/src/valid.rs
+++ b/impl/src/valid.rs
@@ -30,6 +30,18 @@ impl Struct<'_> {
                 ));
             }
         }
+        if let Some(crate::attr::Bound {
+            original: bound_span,
+            ..
+        }) = self.attrs.bound
+        {
+            if self.generics.params.is_empty() {
+                return Err(Error::new_spanned(
+                    bound_span,
+                    "#[error(bound = ...)] requires generics to apply bounds against",
+                ));
+            }
+        }
         check_field_attrs(&self.fields)?;
         for field in &self.fields {
             field.validate()?;
@@ -49,6 +61,18 @@ impl Enum<'_> {
                 return Err(Error::new_spanned(
                     variant.original,
                     "missing #[error(\"...\")] display attribute",
+                ));
+            }
+        }
+        if let Some(crate::attr::Bound {
+            original: bound_span,
+            ..
+        }) = self.attrs.bound
+        {
+            if self.generics.params.is_empty() {
+                return Err(Error::new_spanned(
+                    bound_span,
+                    "#[error(bound = ...)] requires at least one generic type parameter",
                 ));
             }
         }

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -6,7 +6,14 @@ use std::io;
 use thiserror::Error;
 
 macro_rules! unimplemented_display {
-    (($tp:tt), $ty:ty) => {
+    ($($tl:lifetime),*; $tp:tt; $ty:ty) => {
+        impl<$($tl),*, $tp> Display for $ty {
+            fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
+                unimplemented!()
+            }
+        }
+    };
+    ($tp:tt; $ty:ty) => {
         impl<$tp> Display for $ty {
             fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
                 unimplemented!()
@@ -87,6 +94,18 @@ struct WithGenericStruct<T> {
 }
 
 #[derive(Error, Debug)]
+#[error(bound = std::error::Error + 'static)]
+struct WithGenericStructRef<'a, T> {
+    inner: &'a WithGenericStruct<T>,
+}
+
+#[derive(Error, Debug)]
+#[error(bound = std::error::Error + 'a)]
+struct WithGenericStructRefNonStatic<'a, T> {
+    inner: &'a WithGenericStruct<T>,
+}
+
+#[derive(Error, Debug)]
 #[error(bound = std::fmt::Display + std::error::Error + 'static)]
 #[error(transparent)]
 struct WithGenericStructTransparent<T> {
@@ -100,6 +119,8 @@ unimplemented_display!(UnitError);
 unimplemented_display!(WithSource);
 unimplemented_display!(WithAnyhow);
 unimplemented_display!(EnumError);
-unimplemented_display!((T), WithGeneric<T>);
-unimplemented_display!((T), WithGenericFrom<T>);
-unimplemented_display!((T), WithGenericStruct<T>);
+unimplemented_display!(T; WithGeneric<T>);
+unimplemented_display!(T; WithGenericFrom<T>);
+unimplemented_display!(T; WithGenericStruct<T>);
+unimplemented_display!('a; T; WithGenericStructRef<'a, T>);
+unimplemented_display!('a; T; WithGenericStructRefNonStatic<'a, T>);

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -6,6 +6,13 @@ use std::io;
 use thiserror::Error;
 
 macro_rules! unimplemented_display {
+    (($tp:tt), $ty:ty) => {
+        impl<$tp> Display for $ty {
+            fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
+                unimplemented!()
+            }
+        }
+    };
     ($ty:ty) => {
         impl Display for $ty {
             fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -49,9 +56,50 @@ enum EnumError {
     Unit,
 }
 
+#[derive(Error, Debug)]
+#[error(bound = std::fmt::Display + std::error::Error + 'static)]
+enum WithGeneric<T> {
+    Variant,
+    Generic(T),
+}
+
+#[derive(Error, Debug)]
+#[error(bound = std::fmt::Debug + std::error::Error + 'static)]
+enum WithGenericFrom<T> {
+    Variant,
+    Generic(#[from] T),
+}
+
+#[derive(Error, Debug)]
+#[error(bound = std::fmt::Display + std::fmt::Debug + std::error::Error + 'static)]
+enum WithGenericTransparent<T> {
+    #[error("variant")]
+    Variant,
+    #[error(transparent)]
+    Generic(#[from] T),
+}
+
+#[derive(Error, Debug)]
+#[error(bound = std::error::Error + 'static)]
+struct WithGenericStruct<T> {
+    #[from]
+    inner: T,
+}
+
+#[derive(Error, Debug)]
+#[error(bound = std::fmt::Display + std::error::Error + 'static)]
+#[error(transparent)]
+struct WithGenericStructTransparent<T> {
+    #[from]
+    inner: T,
+}
+
 unimplemented_display!(BracedError);
 unimplemented_display!(TupleError);
 unimplemented_display!(UnitError);
 unimplemented_display!(WithSource);
 unimplemented_display!(WithAnyhow);
 unimplemented_display!(EnumError);
+unimplemented_display!((T), WithGeneric<T>);
+unimplemented_display!((T), WithGenericFrom<T>);
+unimplemented_display!((T), WithGenericStruct<T>);

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -101,7 +101,16 @@ struct WithGenericStructRef<'a, T> {
 
 #[derive(Error, Debug)]
 #[error(bound = std::error::Error + 'a)]
-struct WithGenericStructRefNonStatic<'a, T> {
+struct WithGenericStructRefNonStaticInline<'a, T: 'a> {
+    inner: &'a WithGenericStruct<T>,
+}
+
+#[derive(Error, Debug)]
+#[error(bound = std::error::Error + 'a)]
+struct WithGenericStructRefNonStaticWhere<'a, T>
+where
+    T: 'a,
+{
     inner: &'a WithGenericStruct<T>,
 }
 
@@ -123,4 +132,5 @@ unimplemented_display!(T; WithGeneric<T>);
 unimplemented_display!(T; WithGenericFrom<T>);
 unimplemented_display!(T; WithGenericStruct<T>);
 unimplemented_display!('a; T; WithGenericStructRef<'a, T>);
-unimplemented_display!('a; T; WithGenericStructRefNonStatic<'a, T>);
+unimplemented_display!('a; T; WithGenericStructRefNonStaticInline<'a, T>);
+unimplemented_display!('a; T; WithGenericStructRefNonStaticWhere<'a, T>);

--- a/tests/ui/bound-enum-without-generic.rs
+++ b/tests/ui/bound-enum-without-generic.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(bound = std::error::Error + 'static)]
+enum BoundsWithoutGeneric {
+    Variant(u32),
+}
+
+impl std::fmt::Display for BoundsWithoutGeneric {
+    fn fmt(&self, _formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/tests/ui/bound-enum-without-generic.stderr
+++ b/tests/ui/bound-enum-without-generic.stderr
@@ -1,0 +1,5 @@
+error: #[error(bound = ...)] requires at least one generic type parameter
+ --> $DIR/bound-enum-without-generic.rs:4:1
+  |
+4 | #[error(bound = std::error::Error + 'static)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/bound-struct-without-generic.rs
+++ b/tests/ui/bound-struct-without-generic.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(bound = std::error::Error + 'static)]
+struct BoundsWithoutGeneric {
+    inner: u32,
+}
+
+impl std::fmt::Display for BoundsWithoutGeneric {
+    fn fmt(&self, _formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/tests/ui/bound-struct-without-generic.stderr
+++ b/tests/ui/bound-struct-without-generic.stderr
@@ -1,0 +1,5 @@
+error: #[error(bound = ...)] requires generics to apply bounds against
+ --> $DIR/bound-struct-without-generic.rs:4:1
+  |
+4 | #[error(bound = std::error::Error + 'static)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/bound-struct-without-generic.stderr
+++ b/tests/ui/bound-struct-without-generic.stderr
@@ -1,4 +1,4 @@
-error: #[error(bound = ...)] requires generics to apply bounds against
+error: #[error(bound = ...)] requires at least one generic type parameter
  --> $DIR/bound-struct-without-generic.rs:4:1
   |
 4 | #[error(bound = std::error::Error + 'static)]


### PR DESCRIPTION
Attempts to fix #79 via the bounds suggestion in [dtolnay's comment](/dtolnay/thiserror/issues/79#issuecomment-619140294).

Note that this adds the bounds to any constructed `Display` instance as well as the `std::error::Error` instance, which may deviate from intent; if that is not desired, or if a separate `display_bound` parameter would be preferred, it would be trivial to remove or separate.