### PR TITLE
Automatic Generic-Derived Qualifiers

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0.45"
+syn = { version = "1.0.45", features = ["visit"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -15,32 +15,12 @@ pub struct Attrs<'a> {
     pub transparent: Option<Transparent<'a>>,
 }
 
-#[derive(Clone, Copy)]
-pub enum DisplayFormatMarking<'a> {
-    Debug(&'a crate::ast::Field<'a>),
-    Display(&'a crate::ast::Field<'a>),
-}
-
 #[derive(Clone)]
 pub struct Display<'a> {
     pub original: &'a Attribute,
     pub fmt: LitStr,
     pub args: TokenStream,
     pub has_bonus_display: bool,
-}
-
-impl<'a> Display<'a> {
-    pub fn iter_fmt_types(
-        &'a self,
-        fields: &'a [crate::ast::Field],
-    ) -> impl Iterator<Item = DisplayFormatMarking> + 'a {
-        // TODO: Parse format string literal, return only fields at offsets which are Display or Debug referenced by each format reference
-        //       If a field position is referenced multiple times for the same format class, deduplicate
-        fields
-            .iter()
-            .map(DisplayFormatMarking::Display)
-            .chain(fields.iter().map(DisplayFormatMarking::Debug))
-    }
 }
 
 #[derive(Copy, Clone)]

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -15,12 +15,32 @@ pub struct Attrs<'a> {
     pub transparent: Option<Transparent<'a>>,
 }
 
+#[derive(Clone, Copy)]
+pub enum DisplayFormatMarking<'a> {
+    Debug(&'a crate::ast::Field<'a>),
+    Display(&'a crate::ast::Field<'a>),
+}
+
 #[derive(Clone)]
 pub struct Display<'a> {
     pub original: &'a Attribute,
     pub fmt: LitStr,
     pub args: TokenStream,
     pub has_bonus_display: bool,
+}
+
+impl<'a> Display<'a> {
+    pub fn iter_fmt_types(
+        &'a self,
+        fields: &'a [crate::ast::Field],
+    ) -> impl Iterator<Item = DisplayFormatMarking> + 'a {
+        // TODO: Parse format string literal, return only fields at offsets which are Display or Debug referenced by each format reference
+        //       If a field position is referenced multiple times for the same format class, deduplicate
+        fields
+            .iter()
+            .map(DisplayFormatMarking::Display)
+            .chain(fields.iter().map(DisplayFormatMarking::Debug))
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -1,4 +1,5 @@
 use crate::ast::{Enum, Field, Input, Struct};
+use crate::fmt::DisplayFormatMarking;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
@@ -119,7 +120,6 @@ fn impl_struct(input: Struct) -> TokenStream {
             .iter()
             .flat_map(|d| d.iter_fmt_types(input.fields.as_slice()))
         {
-            use crate::attr::DisplayFormatMarking;
             let (ty, bound, ast): (
                 &syn::Type,
                 syn::punctuated::Punctuated<syn::TypeParamBound, _>,
@@ -370,7 +370,6 @@ fn impl_enum(input: Enum) -> TokenStream {
                 .iter()
                 .flat_map(move |d| d.iter_fmt_types(&v.fields))
         }) {
-            use crate::attr::DisplayFormatMarking;
             let (ty, bound, ast): (
                 &syn::Type,
                 syn::punctuated::Punctuated<syn::TypeParamBound, _>,

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -3,7 +3,10 @@ use crate::fmt::DisplayFormatMarking;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
-use syn::{parse_quote, Data, DeriveInput, GenericArgument, Member, PathArguments, Result, Type, Visibility};
+use syn::{
+    parse_quote, Data, DeriveInput, GenericArgument, Member, PathArguments, Result, Type,
+    Visibility,
+};
 
 pub fn derive(node: &DeriveInput) -> Result<TokenStream> {
     let input = Input::from_syn(node)?;
@@ -203,7 +206,11 @@ fn impl_struct(input: Struct) -> TokenStream {
         }
         (
             generic_field_types,
-            generics_in_from_types.generics.into_keys().collect(),
+            generics_in_from_types
+                .generics
+                .into_iter()
+                .map(|(k, _v)| k)
+                .collect(),
         )
     };
 
@@ -505,7 +512,11 @@ fn impl_enum(input: Enum) -> TokenStream {
         }
         (
             generic_field_types,
-            generics_in_from_types.generics.into_keys().collect(),
+            generics_in_from_types
+                .generics
+                .into_iter()
+                .map(|(k, _v)| k)
+                .collect(),
         )
     };
 

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -280,21 +280,33 @@ mod tests {
     fn parse_and_emit_format_strings() {
         let test_str = "\"hello world {{{:} {x:#?} {1} {2:}\"";
         let template_groups = parse_fmt_template(test_str);
-        assert!(matches!(
-            &template_groups[0],
+        assert!(match &template_groups[0] {
             FormatInterpolation {
                 target: None,
-                format: None
-            }
-        ));
-        assert!(
-            matches!(&template_groups[1], FormatInterpolation { target: Some(Member::Named(x)), format: Some(fmt) } if x.to_token_stream().to_string() == "x" && fmt == "#?")
-        );
-        assert!(
-            matches!(&template_groups[2], FormatInterpolation { target: Some(Member::Unnamed(idx)), format: None } if idx.index == 1)
-        );
-        assert!(
-            matches!(&template_groups[3], FormatInterpolation { target: Some(Member::Unnamed(idx)), format: None } if idx.index == 2)
-        );
+                format: None,
+            } => true,
+            _ => false,
+        });
+        assert!(match &template_groups[1] {
+            FormatInterpolation {
+                target: Some(Member::Named(x)),
+                format: Some(fmt),
+            } if x.to_token_stream().to_string() == "x" && fmt == "#?" => true,
+            _ => false,
+        });
+        assert!(match &template_groups[2] {
+            FormatInterpolation {
+                target: Some(Member::Unnamed(idx)),
+                format: None,
+            } if idx.index == 1 => true,
+            _ => false,
+        });
+        assert!(match &template_groups[3] {
+            FormatInterpolation {
+                target: Some(Member::Unnamed(idx)),
+                format: None,
+            } if idx.index == 2 => true,
+            _ => false,
+        });
     }
 }

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -1,7 +1,7 @@
 use crate::{ast::Field, attr::Display};
 use proc_macro2::{Span, TokenTree};
 use quote::{format_ident, quote_spanned};
-use std::{collections::HashSet as Set, convert::TryInto};
+use std::collections::HashSet as Set;
 use syn::{
     ext::IdentExt,
     parse::{ParseStream, Parser},
@@ -154,9 +154,9 @@ impl From<(Option<&str>, Option<&str>)> for FormatInterpolation {
     fn from((target, style): (Option<&str>, Option<&str>)) -> Self {
         let target = match target {
             None => None,
-            Some(s) => Some(if let std::result::Result::<usize, _>::Ok(i) = s.parse() {
+            Some(s) => Some(if let Ok(i) = s.parse::<usize>() {
                 Member::Unnamed(syn::Index {
-                    index: i.try_into().unwrap(),
+                    index: i as u32,
                     span: Span::call_site(),
                 })
             } else {

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -61,16 +61,15 @@ enum DirectEmbedding<Embedded> {
 ///
 /// impl<Indirect> Error for FromGenericError<Indirect>
 /// where
-///     SourceGenericError<Indirect>: Error,
+///     DirectEmbedding<Indirect>: Error,
 ///     Indirect: 'static,
 ///     Self: Debug + Display;
 /// ```
-// TODO: Parse generic parameters contained in #[from] usages and add them to Error impl
-// #[derive(Error, Debug)]
-// enum FromGenericError<Indirect> {
-//     #[error("Tadah")]
-//     SourceEmbedded(#[from] DirectEmbedding<Indirect>),
-// }
+#[derive(Error, Debug)]
+enum FromGenericError<Indirect> {
+    #[error("Tadah")]
+    SourceEmbedded(#[from] DirectEmbedding<Indirect>),
+}
 
 /// Direct embedding of a generic in a field
 ///

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -99,7 +99,7 @@ impl<HasDisplay, HasDebug, HasNeither> Debug
     for HybridDisplayType<HasDisplay, HasDebug, HasNeither>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "HybridDisplayType")
+        write!(f, stringify!(HybridDisplayType))
     }
 }
 
@@ -108,4 +108,23 @@ fn display_hybrid_display_type(
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
     Debug::fmt(&instance, f)
+}
+
+#[derive(Error, Debug)]
+#[error("{0:?}")]
+struct DirectEmbeddingStructTuple<Embedded>(Embedded);
+
+#[derive(Error, Debug)]
+#[error("{direct:?}")]
+struct DirectEmbeddingStructNominal<Embedded> {
+    direct: Embedded,
+}
+
+#[derive(Error, Debug)]
+struct FromGenericErrorStructTuple<Indirect>(#[from] DirectEmbedding<Indirect>);
+
+#[derive(Error, Debug)]
+struct FromGenericErrorStructNominal<Indirect> {
+    #[from]
+    indirect: DirectEmbedding<Indirect>,
 }

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -1,0 +1,112 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![allow(
+    // Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7422
+    clippy::nonstandard_macro_braces,
+)]
+#![allow(dead_code)]
+
+use std::fmt::{Debug, Display};
+
+use thiserror::Error;
+
+struct NoFormattingType;
+
+struct DisplayType;
+
+impl Display for DisplayType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, stringify!(DisplayType))
+    }
+}
+
+impl Debug for DisplayType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, stringify!(DisplayType))
+    }
+}
+
+struct DebugType;
+
+impl Debug for DebugType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, stringify!(DebugType))
+    }
+}
+
+/// Direct embedding of a generic in a field
+///
+/// Should produce the following instances:
+///
+/// ```rust
+/// impl<Embedded> Display for DirectEmbedding<Embedded>
+/// where
+///     Embedded: Debug;
+///
+/// impl<Embedded> Error for DirectEmbedding<Embedded>
+/// where
+///     Self: Debug + Display;
+/// ```
+#[derive(Error, Debug)]
+enum DirectEmbedding<Embedded> {
+    #[error("{0:?}")]
+    FatalError(Embedded),
+}
+
+/// #[from] handling but no Debug usage of the generic
+///
+/// Should produce the following instances:
+///
+/// ```rust
+/// impl<Indirect> Display for FromGenericError<Indirect>;
+///
+/// impl<Indirect> Error for FromGenericError<Indirect>
+/// where
+///     SourceGenericError<Indirect>: Error,
+///     Indirect: 'static,
+///     Self: Debug + Display;
+/// ```
+// TODO: Parse generic parameters contained in #[from] usages and add them to Error impl
+// #[derive(Error, Debug)]
+// enum FromGenericError<Indirect> {
+//     #[error("Tadah")]
+//     SourceEmbedded(#[from] DirectEmbedding<Indirect>),
+// }
+
+/// Direct embedding of a generic in a field
+///
+/// Should produce the following instances:
+///
+/// ```rust
+/// impl<HasDisplay, HasDebug> Display for DirectEmbedding<HasDisplay, HasDebug>
+/// where
+///     HasDisplay: Display,
+///     HasDebug: Debug;
+///
+/// impl<HasDisplay, HasDebug> Error for DirectEmbedding<HasDisplay, HasDebug>
+/// where
+///     Self: Debug + Display;
+/// ```
+#[derive(Error)]
+enum HybridDisplayType<HasDisplay, HasDebug, HasNeither> {
+    #[error("{0} : {1:?}")]
+    HybridDisplayCase(HasDisplay, HasDebug),
+    #[error("{0}")]
+    DisplayCase(HasDisplay, HasNeither),
+    #[error("{1:?}")]
+    DebugCase(HasNeither, HasDebug),
+}
+
+impl<HasDisplay, HasDebug, HasNeither> Debug
+    for HybridDisplayType<HasDisplay, HasDebug, HasNeither>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HybridDisplayType")
+    }
+}
+
+fn display_hybrid_display_type(
+    instance: HybridDisplayType<DisplayType, DebugType, NoFormattingType>,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    Debug::fmt(&instance, f)
+}

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -88,11 +88,11 @@ enum FromGenericError<Indirect> {
 #[derive(Error)]
 enum HybridDisplayType<HasDisplay, HasDebug, HasNeither> {
     #[error("{0} : {1:?}")]
-    HybridDisplayCase(HasDisplay, HasDebug),
+    HybridDisplay(HasDisplay, HasDebug),
     #[error("{0}")]
-    DisplayCase(HasDisplay, HasNeither),
+    Display(HasDisplay, HasNeither),
     #[error("{1:?}")]
-    DebugCase(HasNeither, HasDebug),
+    Debug(HasNeither, HasDebug),
 }
 
 impl<HasDisplay, HasDebug, HasNeither> Debug
@@ -104,7 +104,7 @@ impl<HasDisplay, HasDebug, HasNeither> Debug
 }
 
 fn display_hybrid_display_type(
-    instance: HybridDisplayType<DisplayType, DebugType, NoFormattingType>,
+    instance: &HybridDisplayType<DisplayType, DebugType, NoFormattingType>,
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
     Debug::fmt(&instance, f)


### PR DESCRIPTION
Fixes #79 compliant with feedback from #143.

This PR attempts to produce bounds for generics only where necessitated by their usages.