### PR TITLE
Support #[from] on an Option field

### DIFF
--- a/tests/test_from.rs
+++ b/tests/test_from.rs
@@ -16,7 +16,18 @@ pub struct ErrorStruct {
 
 #[derive(Error, Debug)]
 #[error("...")]
+pub struct ErrorStructOptional {
+    #[from]
+    source: Option<io::Error>,
+}
+
+#[derive(Error, Debug)]
+#[error("...")]
 pub struct ErrorTuple(#[from] io::Error);
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub struct ErrorTupleOptional(#[from] Option<io::Error>);
 
 #[derive(Error, Debug)]
 #[error("...")]
@@ -24,6 +35,15 @@ pub enum ErrorEnum {
     Test {
         #[from]
         source: io::Error,
+    },
+}
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub enum ErrorEnumOptional {
+    Test {
+        #[from]
+        source: Option<io::Error>,
     },
 }
 
@@ -39,7 +59,10 @@ fn assert_impl<T: From<io::Error>>() {}
 #[test]
 fn test_from() {
     assert_impl::<ErrorStruct>();
+    assert_impl::<ErrorStructOptional>();
     assert_impl::<ErrorTuple>();
+    assert_impl::<ErrorTupleOptional>();
     assert_impl::<ErrorEnum>();
+    assert_impl::<ErrorEnumOptional>();
     assert_impl::<Many>();
 }


### PR DESCRIPTION
This allows `?` to work with error types that only sometimes have a source (as seen in #1).

```rust
use std::io;
use thiserror::Error;

#[derive(Error, Debug)]
#[error("...")]
pub struct Error {
    #[from]
    source: Option<io::Error>,
}

fn main() -> Result<(), Error> {
    io::copy(&mut io::empty(), &mut io::sink())?;
    Ok(())
}
```