### PR TITLE
Implied bounds for Display and Error impl

### DIFF
--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
 use quote::{format_ident, quote, ToTokens};
+use std::collections::BTreeSet as Set;
 use std::iter::FromIterator;
 use syn::parse::{Nothing, ParseStream};
 use syn::{
@@ -21,12 +22,19 @@ pub struct Display<'a> {
     pub fmt: LitStr,
     pub args: TokenStream,
     pub has_bonus_display: bool,
+    pub implied_bounds: Set<(usize, Trait)>,
 }
 
 #[derive(Copy, Clone)]
 pub struct Transparent<'a> {
     pub original: &'a Attribute,
     pub span: Span,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Trait {
+    Debug,
+    Display,
 }
 
 pub fn get(input: &[Attribute]) -> Result<Attrs> {
@@ -91,6 +99,7 @@ fn parse_error_attribute<'a>(attrs: &mut Attrs<'a>, attr: &'a Attribute) -> Resu
             fmt: input.parse()?,
             args: parse_token_expr(input, false)?,
             has_bonus_display: false,
+            implied_bounds: Set::new(),
         };
         if attrs.display.is_some() {
             return Err(Error::new_spanned(
@@ -185,6 +194,15 @@ impl ToTokens for Display<'_> {
         let args = &self.args;
         tokens.extend(quote! {
             write!(__formatter, #fmt #args)
+        });
+    }
+}
+
+impl ToTokens for Trait {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(match self {
+            Trait::Debug => quote!(std::fmt::Debug),
+            Trait::Display => quote!(std::fmt::Display),
         });
     }
 }

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -1,8 +1,8 @@
 use crate::ast::Field;
-use crate::attr::Display;
+use crate::attr::{Display, Trait};
 use proc_macro2::TokenTree;
 use quote::{format_ident, quote_spanned};
-use std::collections::HashSet as Set;
+use std::collections::{BTreeSet as Set, HashMap as Map};
 use syn::ext::IdentExt;
 use syn::parse::{ParseStream, Parser};
 use syn::{Ident, Index, LitStr, Member, Result, Token};
@@ -12,7 +12,10 @@ impl Display<'_> {
     pub fn expand_shorthand(&mut self, fields: &[Field]) {
         let raw_args = self.args.clone();
         let mut named_args = explicit_named_args.parse2(raw_args).unwrap();
-        let fields: Set<Member> = fields.iter().map(|f| f.member.clone()).collect();
+        let mut member_index = Map::new();
+        for (i, field) in fields.iter().enumerate() {
+            member_index.insert(field.member.clone(), i);
+        }
 
         let span = self.fmt.span();
         let fmt = self.fmt.value();
@@ -20,6 +23,7 @@ impl Display<'_> {
         let mut out = String::new();
         let mut args = self.args.clone();
         let mut has_bonus_display = false;
+        let mut implied_bounds = Set::new();
 
         let mut has_trailing_comma = false;
         if let Some(TokenTree::Punct(punct)) = args.clone().into_iter().last() {
@@ -47,7 +51,7 @@ impl Display<'_> {
                         Ok(index) => Member::Unnamed(Index { index, span }),
                         Err(_) => return,
                     };
-                    if !fields.contains(&member) {
+                    if !member_index.contains_key(&member) {
                         out += &int;
                         continue;
                     }
@@ -82,9 +86,21 @@ impl Display<'_> {
                 args.extend(quote_spanned!(span=> ,));
             }
             args.extend(quote_spanned!(span=> #formatvar = #local));
-            if read.starts_with('}') && fields.contains(&member) {
-                has_bonus_display = true;
-                args.extend(quote_spanned!(span=> .as_display()));
+            if let Some(&field) = member_index.get(&member) {
+                let end_spec = match read.find('}') {
+                    Some(end_spec) => end_spec,
+                    None => return,
+                };
+                let bound = match read[..end_spec].chars().next_back() {
+                    Some('?') => Trait::Debug,
+                    Some(_) => Trait::Display,
+                    None => {
+                        has_bonus_display = true;
+                        args.extend(quote_spanned!(span=> .as_display()));
+                        Trait::Display
+                    }
+                };
+                implied_bounds.insert((field, bound));
             }
             has_trailing_comma = false;
         }
@@ -93,6 +109,7 @@ impl Display<'_> {
         self.fmt = LitStr::new(&out, self.fmt.span());
         self.args = args;
         self.has_bonus_display = has_bonus_display;
+        self.implied_bounds = implied_bounds;
     }
 }
 

--- a/impl/src/generics.rs
+++ b/impl/src/generics.rs
@@ -1,0 +1,41 @@
+use std::collections::BTreeSet as Set;
+use syn::{GenericArgument, Generics, Ident, PathArguments, Type};
+
+pub struct ParamsInScope<'a> {
+    names: Set<&'a Ident>,
+}
+
+impl<'a> ParamsInScope<'a> {
+    pub fn new(generics: &'a Generics) -> Self {
+        ParamsInScope {
+            names: generics.type_params().map(|param| &param.ident).collect(),
+        }
+    }
+
+    pub fn intersects(&self, ty: &Type) -> bool {
+        let mut found = false;
+        crawl(self, ty, &mut found);
+        found
+    }
+}
+
+fn crawl(in_scope: &ParamsInScope, ty: &Type, found: &mut bool) {
+    if let Type::Path(ty) = ty {
+        if ty.qself.is_none() {
+            if let Some(ident) = ty.path.get_ident() {
+                if in_scope.names.contains(ident) {
+                    *found = true;
+                }
+            }
+        }
+        for segment in &ty.path.segments {
+            if let PathArguments::AngleBracketed(arguments) = &segment.arguments {
+                for arg in &arguments.args {
+                    if let GenericArgument::Type(ty) = arg {
+                        crawl(in_scope, ty, found);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -16,6 +16,7 @@ mod ast;
 mod attr;
 mod expand;
 mod fmt;
+mod generics;
 mod prop;
 mod valid;
 

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -1,0 +1,133 @@
+#![deny(clippy::all, clippy::pedantic)]
+
+use std::fmt::{self, Debug, Display};
+use thiserror::Error;
+
+pub struct NoFormat;
+
+#[derive(Debug)]
+pub struct DebugOnly;
+
+pub struct DisplayOnly;
+
+impl Display for DisplayOnly {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("display only")
+    }
+}
+
+#[derive(Debug)]
+pub struct DebugAndDisplay;
+
+impl Display for DebugAndDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("debug and display")
+    }
+}
+
+/*
+// Should expand to:
+//
+//     impl<E> Display for EnumDebugField<E>
+//     where
+//         E: Debug;
+//
+//     impl<E> Error for EnumDebugField<E>
+//     where
+//         Self: Debug + Display;
+//
+#[derive(Error, Debug)]
+pub enum EnumDebugGeneric<E> {
+    #[error("{0:?}")]
+    FatalError(E),
+}
+
+// Should expand to:
+//
+//     impl<E> Display for EnumFromGeneric<E>;
+//
+//     impl<E> Error for EnumFromGeneric<E>
+//     where
+//         EnumDebugGeneric<E>: Error + 'static,
+//         Self: Debug + Display;
+//
+#[derive(Error, Debug)]
+pub enum EnumFromGeneric<E> {
+    #[error("enum from generic")]
+    Source(#[from] EnumDebugGeneric<E>),
+}
+
+// Should expand to:
+//
+//     impl<HasDisplay, HasDebug, HasNeither> Display
+//         for EnumCompound<HasDisplay, HasDebug, HasNeither>
+//     where
+//         HasDisplay: Display,
+//         HasDebug: Debug;
+//
+//     impl<HasDisplay, HasDebug, HasNeither> Error
+//         for EnumCompound<HasDisplay, HasDebug, HasNeither>
+//     where
+//         Self: Debug + Display;
+//
+#[derive(Error)]
+pub enum EnumCompound<HasDisplay, HasDebug, HasNeither> {
+    #[error("{0} {1:?}")]
+    DisplayDebug(HasDisplay, HasDebug),
+    #[error("{0}")]
+    Display(HasDisplay, HasNeither),
+    #[error("{1:?}")]
+    Debug(HasNeither, HasDebug),
+}
+
+impl<HasDisplay, HasDebug, HasNeither> Debug for EnumCompound<HasDisplay, HasDebug, HasNeither> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("EnumCompound")
+    }
+}
+
+#[test]
+fn test_display_enum_compound() {
+    let mut instance: EnumCompound<DisplayOnly, DebugOnly, NoFormat>;
+
+    instance = EnumCompound::DisplayDebug(DisplayOnly, DebugOnly);
+    assert_eq!(format!("{}", instance), "display only DebugOnly");
+
+    instance = EnumCompound::Display(DisplayOnly, NoFormat);
+    assert_eq!(format!("{}", instance), "display only");
+
+    instance = EnumCompound::Debug(NoFormat, DebugOnly);
+    assert_eq!(format!("{}", instance), "DebugOnly");
+}
+*/
+
+// Should expand to:
+//
+//     impl<E> Display for StructDebugGeneric<E>
+//     where
+//         E: Debug;
+//
+//     impl<E> Error for StructDebugGeneric<E>
+//     where
+//         Self: Debug + Display;
+//
+#[derive(Error, Debug)]
+#[error("{underlying:?}")]
+pub struct StructDebugGeneric<E> {
+    pub underlying: E,
+}
+
+/*
+// Should expand to:
+//
+//     impl<E> Error for StructFromGeneric<E>
+//     where
+//         StructDebugGeneric<E>: Error + 'static,
+//         Self: Debug + Display;
+//
+#[derive(Error, Debug)]
+pub struct StructFromGeneric<E> {
+    #[from]
+    pub source: StructDebugGeneric<E>,
+}
+*/

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -25,7 +25,6 @@ impl Display for DebugAndDisplay {
     }
 }
 
-/*
 // Should expand to:
 //
 //     impl<E> Display for EnumDebugField<E>
@@ -99,7 +98,6 @@ fn test_display_enum_compound() {
     instance = EnumCompound::Debug(NoFormat, DebugOnly);
     assert_eq!(format!("{}", instance), "DebugOnly");
 }
-*/
 
 // Should expand to:
 //
@@ -117,7 +115,6 @@ pub struct StructDebugGeneric<E> {
     pub underlying: E,
 }
 
-/*
 // Should expand to:
 //
 //     impl<E> Error for StructFromGeneric<E>
@@ -130,4 +127,3 @@ pub struct StructFromGeneric<E> {
     #[from]
     pub source: StructDebugGeneric<E>,
 }
-*/


### PR DESCRIPTION
Closes #79. This PR enables an error type with generic parameter(s):

```rust
#[derive(Error, Debug)]
enum MyError<E, F> {
    #[error("thing {0}")]
    Variant(E),
    #[error("some error")]
    Delegate(#[source] F),
}
```

to emit appropriate impls, without further manual intervention to provide handwritten trait bounds. In the above case namely:

```rust
impl<E, F> Error for MyError<E, F>
where
    F: Error + 'static,
    Self: Debug + Display;

impl<E, F> Display for MyError<E, F>
where
    E: Display;
```

Implied bounds for `error(transparent)` are being done in an upcoming PR.