### PR TITLE
Implied bounds for transparent attribute

### DIFF
--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -101,6 +101,23 @@ fn test_display_enum_compound() {
 
 // Should expand to:
 //
+//     impl<E> Display for EnumTransparentGeneric<E>
+//     where
+//         E: Display;
+//
+//     impl<E> Error for EnumTransparentGeneric<E>
+//     where
+//         E: Error,
+//         Self: Debug + Display;
+//
+#[derive(Error, Debug)]
+pub enum EnumTransparentGeneric<E> {
+    #[error(transparent)]
+    Other(E),
+}
+
+// Should expand to:
+//
 //     impl<E> Display for StructDebugGeneric<E>
 //     where
 //         E: Debug;
@@ -127,3 +144,18 @@ pub struct StructFromGeneric<E> {
     #[from]
     pub source: StructDebugGeneric<E>,
 }
+
+// Should expand to:
+//
+//     impl<E> Display for StructTransparentGeneric<E>
+//     where
+//         E: Display;
+//
+//     impl<E> Error for StructTransparentGeneric<E>
+//     where
+//         E: Error,
+//         Self: Debug + Display;
+//
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct StructTransparentGeneric<E>(E);


### PR DESCRIPTION
This is the remaining piece of #79.

The field of a transparent variant is required to implement Display and Error (not necessarily 'static), since we delegate those two traits to it.

```rust
#[derive(Error, Debug)]
enum MyError<E> {
    #[error(transparent)]
    Delegate(#[from] E),
}
```

```rust
// generated

impl<E> Error for MyError<E>
where
    E: Error,
    Self: Debug + Display;

impl<E> Display for MyError<E>
where
    E: Display;

impl<E> From<E> for MyError<E>;
```