### PR TITLE
Implied bounds for the remaining std::fmt traits

### DIFF
--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -31,10 +31,17 @@ pub struct Transparent<'a> {
     pub span: Span,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub enum Trait {
     Debug,
     Display,
+    Octal,
+    LowerHex,
+    UpperHex,
+    Pointer,
+    Binary,
+    LowerExp,
+    UpperExp,
 }
 
 pub fn get(input: &[Attribute]) -> Result<Attrs> {
@@ -200,9 +207,7 @@ impl ToTokens for Display<'_> {
 
 impl ToTokens for Trait {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(match self {
-            Trait::Debug => quote!(std::fmt::Debug),
-            Trait::Display => quote!(std::fmt::Display),
-        });
+        let trait_name = format_ident!("{}", format!("{:?}", self));
+        tokens.extend(quote!(std::fmt::#trait_name));
     }
 }

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -93,6 +93,13 @@ impl Display<'_> {
                 };
                 let bound = match read[..end_spec].chars().next_back() {
                     Some('?') => Trait::Debug,
+                    Some('o') => Trait::Octal,
+                    Some('x') => Trait::LowerHex,
+                    Some('X') => Trait::UpperHex,
+                    Some('p') => Trait::Pointer,
+                    Some('b') => Trait::Binary,
+                    Some('e') => Trait::LowerExp,
+                    Some('E') => Trait::UpperExp,
                     Some(_) => Trait::Display,
                     None => {
                         has_bonus_display = true;


### PR DESCRIPTION
For example, the following needs the generated `Display` impl to have `where T: Octal + Pointer`.

```rust
#[derive(Error, Debug)]
enum MyError<T> {
    #[error("{0:o}")]
    Oct(T),
    #[error("{0:p}")]
    Ptr(T),
}
```