### PR TITLE
Deduplicate inferred bounds

### DIFF
--- a/impl/src/generics.rs
+++ b/impl/src/generics.rs
@@ -1,5 +1,9 @@
-use std::collections::BTreeSet as Set;
-use syn::{GenericArgument, Generics, Ident, PathArguments, Type};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap as Map, BTreeSet as Set};
+use syn::punctuated::Punctuated;
+use syn::{parse_quote, GenericArgument, Generics, Ident, PathArguments, Token, Type, WhereClause};
 
 pub struct ParamsInScope<'a> {
     names: Set<&'a Ident>,
@@ -37,5 +41,42 @@ fn crawl(in_scope: &ParamsInScope, ty: &Type, found: &mut bool) {
                 }
             }
         }
+    }
+}
+
+pub struct InferredBounds {
+    bounds: Map<String, (Set<String>, Punctuated<TokenStream, Token![+]>)>,
+    order: Vec<TokenStream>,
+}
+
+impl InferredBounds {
+    pub fn new() -> Self {
+        InferredBounds {
+            bounds: Map::new(),
+            order: Vec::new(),
+        }
+    }
+
+    pub fn insert(&mut self, ty: impl ToTokens, bound: impl ToTokens) {
+        let ty = ty.to_token_stream();
+        let bound = bound.to_token_stream();
+        let entry = self.bounds.entry(ty.to_string());
+        if let Entry::Vacant(_) = entry {
+            self.order.push(ty);
+        }
+        let (set, tokens) = entry.or_default();
+        if set.insert(bound.to_string()) {
+            tokens.push(bound);
+        }
+    }
+
+    pub fn augment_where_clause(&self, generics: &Generics) -> WhereClause {
+        let mut generics = generics.clone();
+        let where_clause = generics.make_where_clause();
+        for ty in &self.order {
+            let (_set, bounds) = &self.bounds[&ty.to_string()];
+            where_clause.predicates.push(parse_quote!(#ty: #bounds));
+        }
+        generics.where_clause.unwrap()
     }
 }


### PR DESCRIPTION
This PR enables us to generate bounds resembling `T: Display + Debug` instead of like `T: Display, T: Display, T: Debug`. It makes no difference to the type checker but deduplicated bounds are more readable in rustdoc.