### PR TITLE
add UnwindSafe impl for AsDynError

### DIFF
--- a/src/aserror.rs
+++ b/src/aserror.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::panic::UnwindSafe;
 
 pub trait AsDynError<'a> {
     fn as_dyn_error(&self) -> &(dyn Error + 'a);
@@ -26,6 +27,13 @@ impl<'a> AsDynError<'a> for dyn Error + Send + 'a {
 }
 
 impl<'a> AsDynError<'a> for dyn Error + Send + Sync + 'a {
+    #[inline]
+    fn as_dyn_error(&self) -> &(dyn Error + 'a) {
+        self
+    }
+}
+
+impl<'a> AsDynError<'a> for dyn Error + Send + Sync + UnwindSafe + 'a {
     #[inline]
     fn as_dyn_error(&self) -> &(dyn Error + 'a) {
         self


### PR DESCRIPTION
Hello!! I love this crate :))

### Problem
`thiserror::Error` is not able to convert a `Box<dyn Error + Send + Sync + UnwindSafe + 'static>` into a `dyn Error` with the `#[source]` annotation, which caused it to be unsuitable for the purposes of the Signal client: see https://github.com/signalapp/libsignal-client/pull/296#discussion_r723767841. Signal uses [`UnwindSafe`](https://doc.rust-lang.org/1.55.0/std/panic/trait.UnwindSafe.html) (I just learned about this trait) to convert errors into a format suitable for its ffi/jni/node.js bindings.

### Solution
@jrose-signal pointed me to #41, which enabled wrapping a `Box<dyn Error + Send + 'static>` with `#[source]`, and I was able to figure out how to extend it for the purposes of boxed `UnwindSafe` errors as well.

### Result
Using this change allowed me to remove the boilerplate error manipulation code in the signal client, and this commit (https://github.com/cosmicexplorer/libsignal-client/commit/9d82971ec277d1a15e2c60fa09812b0094967ae7) passed tests locally.

Please let me know if there are test cases I should add -- it looks like the `test_boxed_source()` method is already intended to apply to all the types of boxed errors `thiserror` supports, and I tried to create a test wrapping e.g. `ParseIntError` which is `UnwindSafe` using `std::panic::catch_unwind`, but was having difficulty and was thinking it might be better to leave the tests simple as they are. Let me know if I should investigate more on that.