### PR TITLE
Add example for expressions in `error` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ pub enum DataStoreError {
   }
   ```
 
+  The attribute accepts complex expressions as well. For example, if you'd like
+  to transform an `Option<T>` into something else in the error messsage, you
+  can do so.
+
+  ```rust
+  #[derive(Error, Debug)]
+  pub enum Error {
+      #[error("lost connection to the server: {}", match .0 {
+          Some(reason) => &reason,
+          None => "unknown reason",
+      })]
+      ConnectionLost(Option<String>),
+  }
+
 - A `From` impl is generated for each variant containing a `#[from]` attribute.
 
   Note that the variant must not contain any other fields beyond the source

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,22 @@
 //!   }
 //!   ```
 //!
+//!   The attribute accepts complex expressions as well. For example, if you'd like
+//!   to transform an `Option<T>` into something else in the error messsage, you
+//!   can do so.
+//!
+//!   ```rust
+//!   # use thiserror::Error;
+//!
+//!   #[derive(Error, Debug)]
+//!   pub enum Error {
+//!       #[error("lost connection to the server: {}", match .0 {
+//!           Some(reason) => &reason,
+//!           None => "unknown reason",
+//!       })]
+//!       ConnectionLost(Option<String>),
+//!   }
+//!
 //! - A `From` impl is generated for each variant containing a `#[from]`
 //!   attribute.
 //!


### PR DESCRIPTION
Hi @dtolnay, that you so much for this awesome crate. I use it everywhere all the time (together with `anyhow`).

Was trying to figure out how to nicely display an `Option<T>` value in the error message, instead of just using `{0:?}` and having `Some("...")/None` in the displayed message.

So I found a nice test case in `tests/test_display.rs`, and thought it might be nice to add a tiny
example to the README.md and crate docs, to showcase that expressions are possible in the `#[error("...")]` attribute as well.

Wording of the example could maybe be a bit improved, I'm not as good of a writer as you 🙇‍♂️.
