### PR TITLE
Re-enable deprecated variants test.

### DIFF
--- a/tests/test_deprecated.rs
+++ b/tests/test_deprecated.rs
@@ -1,0 +1,10 @@
+#![deny(deprecated, clippy::all, clippy::pedantic)]
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[deprecated]
+    #[error("...")]
+    Deprecated,
+}


### PR DESCRIPTION
This got broken in nightly-2021-06-04 and fixed in nightly-2021-06-06.

Closes #136.