### PR TITLE
Directly call source.provide instead of going through dyn error

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -67,12 +67,12 @@ fn impl_struct(input: Struct) -> TokenStream {
             let source_provide = if type_is_option(source_field.ty) {
                 quote_spanned! {source.span()=>
                     if let std::option::Option::Some(source) = &self.#source {
-                        source.as_dyn_error().provide(#demand);
+                        source.provide(#demand);
                     }
                 }
             } else {
                 quote_spanned! {source.span()=>
-                    self.#source.as_dyn_error().provide(#demand);
+                    self.#source.provide(#demand);
                 }
             };
             let self_provide = if source == backtrace {
@@ -89,7 +89,8 @@ fn impl_struct(input: Struct) -> TokenStream {
                 })
             };
             quote! {
-                use thiserror::__private::AsDynError;
+                #[allow(unused_imports)]
+                use std::error::Error as _;
                 #source_provide
                 #self_provide
             }
@@ -259,12 +260,12 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let source_provide = if type_is_option(source_field.ty) {
                         quote_spanned! {source.span()=>
                             if let std::option::Option::Some(source) = #varsource {
-                                source.as_dyn_error().provide(#demand);
+                                source.provide(#demand);
                             }
                         }
                     } else {
                         quote_spanned! {source.span()=>
-                            #varsource.as_dyn_error().provide(#demand);
+                            #varsource.provide(#demand);
                         }
                     };
                     let self_provide = if type_is_option(backtrace_field.ty) {
@@ -284,7 +285,8 @@ fn impl_enum(input: Enum) -> TokenStream {
                             #source: #varsource,
                             ..
                         } => {
-                            use thiserror::__private::AsDynError;
+                            #[allow(unused_imports)]
+                            use std::error::Error as _;
                             #source_provide
                             #self_provide
                         }
@@ -298,17 +300,18 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let source_provide = if type_is_option(source_field.ty) {
                         quote_spanned! {backtrace.span()=>
                             if let std::option::Option::Some(source) = #varsource {
-                                source.as_dyn_error().provide(#demand);
+                                source.provide(#demand);
                             }
                         }
                     } else {
                         quote_spanned! {backtrace.span()=>
-                            #varsource.as_dyn_error().provide(#demand);
+                            #varsource.provide(#demand);
                         }
                     };
                     quote! {
                         #ty::#ident {#backtrace: #varsource, ..} => {
-                            use thiserror::__private::AsDynError;
+                            #[allow(unused_imports)]
+                            use std::error::Error as _;
                             #source_provide
                         }
                     }


### PR DESCRIPTION
From https://github.com/dtolnay/thiserror/blob/1.0.33/src/aserror.rs, the `.as_dyn_error()` method exists if the #\[source\] has a std::error::Error impl, or derefs to something with a std::error::Error impl, or derefs to `dyn Error + …` (such as `Box<dyn Error>` would do).

None of those cases require the thiserror-generated `provide` method to actually go through `dyn Error`. We can directly call the `provide` method, which will do the deref'ing and then call `provide` from either the type's std::error::Error impl or from `dyn Error`'s vtable.

This wasn't possible prior to #182 because `.backtrace()` couldn't have been called directly the same way, since anyhow::Error has a backtrace method with a different signature than std::error::Error's backtrace method (`-> &Backtrace` vs `-> Option<&Backtrace>`).