### PR TITLE
Add Sealed supertrait to private AsDynError trait

### DIFF
--- a/src/aserror.rs
+++ b/src/aserror.rs
@@ -1,7 +1,8 @@
+use self::private::Sealed;
 use std::error::Error;
 use std::panic::UnwindSafe;
 
-pub trait AsDynError<'a> {
+pub trait AsDynError<'a>: Sealed {
     fn as_dyn_error(&self) -> &(dyn Error + 'a);
 }
 
@@ -38,4 +39,15 @@ impl<'a> AsDynError<'a> for dyn Error + Send + Sync + UnwindSafe + 'a {
     fn as_dyn_error(&self) -> &(dyn Error + 'a) {
         self
     }
+}
+
+mod private {
+    use super::*;
+
+    pub trait Sealed {}
+    impl<'a, T: Error + 'a> Sealed for T {}
+    impl<'a> Sealed for dyn Error + 'a {}
+    impl<'a> Sealed for dyn Error + Send + 'a {}
+    impl<'a> Sealed for dyn Error + Send + Sync + 'a {}
+    impl<'a> Sealed for dyn Error + Send + Sync + UnwindSafe + 'a {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,7 @@
     clippy::doc_markdown,
     clippy::module_name_repetitions,
     clippy::return_self_not_must_use,
+    clippy::wildcard_imports,
 )]
 
 mod aserror;


### PR DESCRIPTION
This trait is already private so we don't need to worry about handwritten impls outside the crate, but sealing anyway is nice here because it makes clear when reading aserror.rs that all impls of this trait are visible in the thiserror source code; we don't need to study the derive macro's implementation to distinguish that it isn't emitting impls of this trait.