### PR TITLE
fix UI tests missing lifetime annotations

### DIFF
--- a/tests/ui/source-enum-not-error.stderr
+++ b/tests/ui/source-enum-not-error.stderr
@@ -4,7 +4,7 @@ error[E0599]: the method `as_dyn_error` exists for reference `&NotError`, but it
 4  | pub struct NotError;
    | -------------------
    | |
-   | doesn't satisfy `NotError: AsDynError<'_>`
+   | doesn't satisfy `NotError: AsDynError`
    | doesn't satisfy `NotError: std::error::Error`
 ...
 10 |         source: NotError,
@@ -12,9 +12,9 @@ error[E0599]: the method `as_dyn_error` exists for reference `&NotError`, but it
    |
    = note: the following trait bounds were not satisfied:
            `NotError: std::error::Error`
-           which is required by `NotError: AsDynError<'_>`
+           which is required by `NotError: AsDynError`
            `&NotError: std::error::Error`
-           which is required by `&NotError: AsDynError<'_>`
+           which is required by `&NotError: AsDynError`
 note: the following trait must be implemented
   --> $RUST/core/src/error.rs
    |

--- a/tests/ui/source-struct-not-error.stderr
+++ b/tests/ui/source-struct-not-error.stderr
@@ -5,7 +5,7 @@ error[E0599]: the method `as_dyn_error` exists for struct `NotError`, but its tr
   | ---------------
   | |
   | method `as_dyn_error` not found for this struct
-  | doesn't satisfy `NotError: AsDynError<'_>`
+  | doesn't satisfy `NotError: AsDynError`
   | doesn't satisfy `NotError: std::error::Error`
 ...
 9 |     source: NotError,
@@ -13,7 +13,7 @@ error[E0599]: the method `as_dyn_error` exists for struct `NotError`, but its tr
   |
   = note: the following trait bounds were not satisfied:
           `NotError: std::error::Error`
-          which is required by `NotError: AsDynError<'_>`
+          which is required by `NotError: AsDynError`
 note: the following trait must be implemented
  --> $RUST/core/src/error.rs
   |


### PR DESCRIPTION
This fixes UI tests, so now `cargo test` passes.