### PR TITLE
docs: add `#[error("...")]` example for struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ pub enum DataStoreError {
 
   ```rust
   #[derive(Error, Debug)]
+  #[error("{msg}: {source}")]
   pub struct MyError {
       msg: String,
       #[source]  // optional if field name is `source`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,17 +133,12 @@
 //!   # use thiserror::Error;
 //!   #
 //!   #[derive(Error, Debug)]
+//!   #[error("{msg}: {source}")]
 //!   pub struct MyError {
 //!       msg: String,
 //!       #[source]  // optional if field name is `source`
 //!       source: anyhow::Error,
 //!   }
-//!   #
-//!   # impl Display for MyError {
-//!   #     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-//!   #         unimplemented!()
-//!   #     }
-//!   # }
 //!   ```
 //!
 //! - The Error trait's `provide()` method is implemented to provide whichever


### PR DESCRIPTION
This PR adds a example of implementing `Display` to a struct with `#[error(...)]`.