### PR TITLE
no_std support on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ rust-version = "1.31"
 [dependencies]
 thiserror-impl = { version = "=1.0.38", path = "impl" }
 
+[features]
+default = ["std"]
+std = ["thiserror-impl/std"]
+
 [dev-dependencies]
 anyhow = "1.0.65"
 ref-cast = "1.0"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -16,5 +16,8 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0.45"
 
+[features]
+std = []
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -208,6 +208,6 @@ impl ToTokens for Display<'_> {
 impl ToTokens for Trait {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let trait_name = format_ident!("{}", format!("{:?}", self));
-        tokens.extend(quote!(std::fmt::#trait_name));
+        tokens.extend(quote!(core::fmt::#trait_name));
     }
 }

--- a/src/aserror.rs
+++ b/src/aserror.rs
@@ -1,4 +1,7 @@
-use std::error::Error;
+use crate::__private::error::Error;
+#[cfg(not(feature = "std"))]
+use core::panic::UnwindSafe;
+#[cfg(feature = "std")]
 use std::panic::UnwindSafe;
 
 pub trait AsDynError<'a>: Sealed {

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,4 +1,5 @@
-use std::fmt::Display;
+use core::fmt::Display;
+#[cfg(feature = "std")]
 use std::path::{self, Path, PathBuf};
 
 pub trait DisplayAsDisplay {
@@ -11,16 +12,19 @@ impl<T: Display> DisplayAsDisplay for &T {
     }
 }
 
+#[cfg(feature = "std")]
 pub trait PathAsDisplay {
     fn as_display(&self) -> path::Display<'_>;
 }
 
+#[cfg(feature = "std")]
 impl PathAsDisplay for Path {
     fn as_display(&self) -> path::Display<'_> {
         self.display()
     }
 }
 
+#[cfg(feature = "std")]
 impl PathAsDisplay for PathBuf {
     fn as_display(&self) -> path::Display<'_> {
         self.display()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,10 @@
     clippy::wildcard_imports,
 )]
 #![cfg_attr(provide_any, feature(provide_any))]
+#![cfg_attr(not(feature = "std"), feature(error_in_core))]
+#![no_std]
+#[cfg(feature = "std")]
+extern crate std;
 
 mod aserror;
 mod display;
@@ -247,8 +251,15 @@ pub use thiserror_impl::*;
 // Not public API.
 #[doc(hidden)]
 pub mod __private {
+    #[cfg(not(feature = "std"))]
+    pub use core::error;
+    #[cfg(feature = "std")]
+    pub use std::error;
+
     pub use crate::aserror::AsDynError;
-    pub use crate::display::{DisplayAsDisplay, PathAsDisplay};
+    pub use crate::display::DisplayAsDisplay;
+    #[cfg(feature = "std")]
+    pub use crate::display::PathAsDisplay;
     #[cfg(provide_any)]
     pub use crate::provide::ThiserrorProvide;
 }

--- a/src/provide.rs
+++ b/src/provide.rs
@@ -1,4 +1,4 @@
-use std::any::{Demand, Provider};
+use core::any::{Demand, Provider};
 
 pub trait ThiserrorProvide: Sealed {
     fn thiserror_provide<'a>(&'a self, demand: &mut Demand<'a>);


### PR DESCRIPTION
As mentioned by #196, nightly now has the `error_in_core` feature. This make no_std support pretty straightforward (just replace `std` with `core` in a few places).

Some tests don't work on on no_std to keep the commit small for now. Maybe this is fine until `error_in_core` is merged, because there are only 5 lines in `#[cfg(not(feature = "std"))]` guards, so running the tests with `std` disabled hardly increases coverage anyway

Once `error_in_core` is in stable, even this little trick:

```
#[doc(hidden)]
pub mod __private {
    #[cfg(not(feature = "std"))]
    pub use core::error;
    #[cfg(feature = "std")]
    pub use std::error;
```

can be removed, or not, depending on how important the MSRV guarantees are.

Thoughts?