### PR TITLE
Forbid unsafe code

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![allow(
     clippy::blocks_in_if_conditions,
     clippy::cast_lossless,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,7 @@
 //!
 //!   [`anyhow`]: https://github.com/dtolnay/anyhow
 
+#![forbid(unsafe_code)]
 #![allow(
     // Clippy bug: https://github.com/rust-lang/rust-clippy/issues/7421
     clippy::doc_markdown,


### PR DESCRIPTION
Could you consider forbidding unsafe code in these crates, since they currently do not use any `unsafe` blocks?
This would help make [cargo-geiger](https://github.com/rust-secure-code/cargo-geiger) happy.

Thank you for this awesome crate that makes writing custom errors a breeze!