### PR TITLE
Make use of alternate() flag

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -407,7 +407,14 @@ fn impl_enum(input: Enum) -> TokenStream {
                     #[allow(unused_variables, deprecated, clippy::used_underscore_binding)]
                     match #void_deref self {
                         #(#arms,)*
+                    }?;
+                    if __formatter.alternate() {
+                        if let Some(source) = std::error::Error::source(self) {
+                            std::fmt::Formatter::write_str(__formatter, ": ")?;
+                            std::fmt::Display::fmt(source, __formatter)?;
+                        }
                     }
+                    Ok(())
                 }
             }
         })


### PR DESCRIPTION
This (WIP) PR adds the ability to make use of the `alternate()` flag.

Similar to what `anyhow` does.

Idea:

| Invocation | Output |
| --- | --- |
| format!("{error}") | "cannot complete request" |
| format!("{error:#}") | "cannot complete request: error talking to database: network unreachable" |

