### PR TITLE
Change type in formating example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pub enum DataStoreError {
   ```rust
   #[derive(Error, Debug)]
   pub enum Error {
-      #[error("invalid rdo_lookahead_frames {0} (expected < {})", i32::MAX)]
+      #[error("invalid rdo_lookahead_frames {0} (expected < {})", u32::MAX)]
       InvalidLookahead(u32),
   }
   ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //!   #
 //!   #[derive(Error, Debug)]
 //!   pub enum Error {
-//!       #[error("invalid rdo_lookahead_frames {0} (expected < {})", i32::MAX)]
+//!       #[error("invalid rdo_lookahead_frames {0} (expected < {})", u32::MAX)]
 //!       InvalidLookahead(u32),
 //!   }
 //!   ```


### PR DESCRIPTION
Hi David, thank you for this crate.

This PR is a minor fix in the documentation. Specifically, in a formatting example `#[error("invalid rdo_lookahead_frames {0} (expected < {})", i32::MAX)]` the type should be the same as the field's one, otherwise the message is confusing.
