### PR TITLE
Avoid calling a nonstandard write! macro that might be in scope

### DIFF
--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -197,7 +197,7 @@ impl ToTokens for Display<'_> {
         let fmt = &self.fmt;
         let args = &self.args;
         tokens.extend(quote! {
-            write!(__formatter, #fmt #args)
+            thiserror::__private::write!(__formatter, #fmt #args)
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,4 +252,6 @@ pub mod __private {
     pub use crate::display::{DisplayAsDisplay, PathAsDisplay};
     #[cfg(provide_any)]
     pub use crate::provide::ThiserrorProvide;
+
+    pub use std::write;
 }


### PR DESCRIPTION
Fixes #239.