### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ members = ["impl"]
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--generate-link-to-definition"]
+
+[features]
+no_std = []

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -197,7 +197,7 @@ impl ToTokens for Display<'_> {
         let fmt = &self.fmt;
         let args = &self.args;
         tokens.extend(quote! {
-            std::write!(__formatter, #fmt #args)
+            ::core::write!(__formatter, #fmt #args)
         });
     }
 }
@@ -205,6 +205,6 @@ impl ToTokens for Display<'_> {
 impl ToTokens for Trait {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let trait_name = format_ident!("{}", format!("{:?}", self));
-        tokens.extend(quote!(std::fmt::#trait_name));
+        tokens.extend(quote!(::core::fmt::#trait_name));
     }
 }

--- a/src/aserror.rs
+++ b/src/aserror.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use crate::__private::Error;
 use std::panic::UnwindSafe;
 
 pub trait AsDynError<'a>: Sealed {

--- a/src/aserror.rs
+++ b/src/aserror.rs
@@ -1,5 +1,5 @@
 use crate::__private::Error;
-use std::panic::UnwindSafe;
+use core::panic::UnwindSafe;
 
 pub trait AsDynError<'a>: Sealed {
     fn as_dyn_error(&self) -> &(dyn Error + 'a);

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,28 +1,53 @@
 use std::fmt::Display;
-use std::path::{self, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
-pub trait DisplayAsDisplay {
-    fn as_display(&self) -> Self;
+pub trait AsDisplay {
+    type Target: Display + ?Sized;
+
+    fn as_display(&self) -> &Self::Target;
 }
 
-impl<T: Display> DisplayAsDisplay for &T {
-    fn as_display(&self) -> Self {
+impl<T: Display> AsDisplay for &T {
+    type Target = T;
+
+    fn as_display(&self) -> &Self::Target {
         self
     }
 }
 
-pub trait PathAsDisplay {
-    fn as_display(&self) -> path::Display<'_>;
-}
+impl AsDisplay for Path {
+    type Target = PathDisplay;
 
-impl PathAsDisplay for Path {
-    fn as_display(&self) -> path::Display<'_> {
-        self.display()
+    #[inline(always)]
+    fn as_display(&self) -> &Self::Target {
+        PathDisplay::new(self)
     }
 }
 
-impl PathAsDisplay for PathBuf {
-    fn as_display(&self) -> path::Display<'_> {
-        self.display()
+impl AsDisplay for PathBuf {
+    type Target = PathDisplay;
+
+    #[inline(always)]
+    fn as_display(&self) -> &Self::Target {
+        PathDisplay::new(self.as_path())
+    }
+}
+
+#[repr(transparent)]
+pub struct PathDisplay(Path);
+
+impl PathDisplay {
+    #[inline(always)]
+    fn new(path: &Path) -> &Self {
+        // SAFETY: PathDisplay is repr(transparent) so casting pointers between
+        // it and its payload is safe.
+        unsafe { &*(path as *const Path as *const Self) }
+    }
+}
+
+impl Display for PathDisplay {
+    #[inline(always)]
+    fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.display().fmt(fmtr)
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,4 @@
-use std::fmt::Display;
-use std::path::{Path, PathBuf};
+use core::fmt::Display;
 
 pub trait AsDisplay {
     type Target: Display + ?Sized;
@@ -15,39 +14,44 @@ impl<T: Display> AsDisplay for &T {
     }
 }
 
-impl AsDisplay for Path {
-    type Target = PathDisplay;
+#[cfg(not(feature = "no_std"))]
+mod path {
+    use std::path::{Path, PathBuf};
 
-    #[inline(always)]
-    fn as_display(&self) -> &Self::Target {
-        PathDisplay::new(self)
+    impl super::AsDisplay for Path {
+        type Target = PathDisplay;
+
+        #[inline(always)]
+        fn as_display(&self) -> &Self::Target {
+            PathDisplay::new(self)
+        }
     }
-}
 
-impl AsDisplay for PathBuf {
-    type Target = PathDisplay;
+    impl super::AsDisplay for PathBuf {
+        type Target = PathDisplay;
 
-    #[inline(always)]
-    fn as_display(&self) -> &Self::Target {
-        PathDisplay::new(self.as_path())
+        #[inline(always)]
+        fn as_display(&self) -> &Self::Target {
+            PathDisplay::new(self.as_path())
+        }
     }
-}
 
-#[repr(transparent)]
-pub struct PathDisplay(Path);
+    #[repr(transparent)]
+    pub struct PathDisplay(Path);
 
-impl PathDisplay {
-    #[inline(always)]
-    fn new(path: &Path) -> &Self {
-        // SAFETY: PathDisplay is repr(transparent) so casting pointers between
-        // it and its payload is safe.
-        unsafe { &*(path as *const Path as *const Self) }
+    impl PathDisplay {
+        #[inline(always)]
+        fn new(path: &Path) -> &Self {
+            // SAFETY: PathDisplay is repr(transparent) so casting pointers
+            // between it and its payload is safe.
+            unsafe { &*(path as *const Path as *const Self) }
+        }
     }
-}
 
-impl Display for PathDisplay {
-    #[inline(always)]
-    fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.0.display().fmt(fmtr)
+    impl core::fmt::Display for PathDisplay {
+        #[inline(always)]
+        fn fmt(&self, fmtr: &mut core::fmt::Formatter) -> core::fmt::Result {
+            self.0.display().fmt(fmtr)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ pub use thiserror_impl::*;
 #[doc(hidden)]
 pub mod __private {
     pub use crate::aserror::AsDynError;
-    pub use crate::display::{DisplayAsDisplay, PathAsDisplay};
+    pub use crate::display::AsDisplay;
     #[cfg(provide_any)]
     pub use crate::provide::ThiserrorProvide;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,8 @@
     clippy::wildcard_imports,
 )]
 #![cfg_attr(provide_any, feature(provide_any))]
+#![cfg_attr(feature = "no_std", feature(error_in_core))]
+#![cfg_attr(feature = "no_std", no_std)]
 
 mod aserror;
 mod display;
@@ -252,5 +254,8 @@ pub mod __private {
     pub use crate::display::AsDisplay;
     #[cfg(provide_any)]
     pub use crate::provide::ThiserrorProvide;
+    #[cfg(feature = "no_std")]
+    pub use core::error::Error;
+    #[cfg(not(feature = "no_std"))]
     pub use std::error::Error;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,4 +252,5 @@ pub mod __private {
     pub use crate::display::AsDisplay;
     #[cfg(provide_any)]
     pub use crate::provide::ThiserrorProvide;
+    pub use std::error::Error;
 }

--- a/src/provide.rs
+++ b/src/provide.rs
@@ -1,4 +1,4 @@
-use std::any::{Demand, Provider};
+use core::any::{Demand, Provider};
 
 pub trait ThiserrorProvide: Sealed {
     fn thiserror_provide<'a>(&'a self, demand: &mut Demand<'a>);

--- a/tests/ui/no-display.stderr
+++ b/tests/ui/no-display.stderr
@@ -9,7 +9,7 @@ error[E0599]: the method `as_display` exists for reference `&NoDisplay`, but its
   |
   = note: the following trait bounds were not satisfied:
           `NoDisplay: std::fmt::Display`
-          which is required by `&NoDisplay: DisplayAsDisplay`
+          which is required by `&NoDisplay: AsDisplay`
 note: the trait `std::fmt::Display` must be implemented
  --> $RUST/core/src/fmt/mod.rs
   |


### PR DESCRIPTION
Note: When reviewing and merging the changes it’s best to look at each commit individually rather than combined changes.  Each commit in the PR is self-contained with message describing what it’s doing.  I can send each as separate PR if that’d be easier to handle.

This adds no_std support by introducing `no_std` feature.  Enabling that feature requires nightly compiler thus I was also contemplating whether `unstable` would be a better choice.

Arguably it would be better to have a `std` feature instead which is enabled by default but doing that could break `default-features = false` builds.
