### PR TITLE
Replace DisplayAsDisplay and PathAsDisplay with AsDisplay trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ pub mod __private {
     #[doc(hidden)]
     pub use crate::aserror::AsDynError;
     #[doc(hidden)]
-    pub use crate::display::{DisplayAsDisplay, PathAsDisplay};
+    pub use crate::display::AsDisplay;
     #[cfg(error_generic_member_access)]
     #[doc(hidden)]
     pub use crate::provide::ThiserrorProvide;

--- a/tests/ui/no-display.stderr
+++ b/tests/ui/no-display.stderr
@@ -9,7 +9,7 @@ error[E0599]: the method `as_display` exists for reference `&NoDisplay`, but its
   |
   = note: the following trait bounds were not satisfied:
           `NoDisplay: std::fmt::Display`
-          which is required by `&NoDisplay: DisplayAsDisplay`
+          which is required by `&NoDisplay: AsDisplay`
 note: the trait `std::fmt::Display` must be implemented
  --> $RUST/core/src/fmt/mod.rs
   |


### PR DESCRIPTION
Rather than having separate traits implementing as_display method,
replace DisplayAsDisplay and PathAsDisplay traits with a AsDisplay
trait.  The difference between those two traits is in the result
returned by the as_display method.  With AsDisplay trait this is
captured by an associated type.

The main motivation for the change is making it simpler to support
no_std builds in the future.  Previously, PathAsDisplay would have to
be handled specially in such builds on the side of macro
expansion. Now, thiserror-impl doesn’t need to be aware of any
complications around AsDisplay since they are all contained in
thiserror crate.
