### PR TITLE
Prefer core crate in macro expansions

### DIFF
--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -197,7 +197,7 @@ impl ToTokens for Display<'_> {
         let fmt = &self.fmt;
         let args = &self.args;
         tokens.extend(quote! {
-            std::write!(__formatter, #fmt #args)
+            ::core::write!(__formatter, #fmt #args)
         });
     }
 }
@@ -205,6 +205,6 @@ impl ToTokens for Display<'_> {
 impl ToTokens for Trait {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let trait_name = format_ident!("{}", format!("{:?}", self));
-        tokens.extend(quote!(std::fmt::#trait_name));
+        tokens.extend(quote!(::core::fmt::#trait_name));
     }
 }

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -45,14 +45,14 @@ fn impl_struct(input: Struct) -> TokenStream {
         };
         let dyn_error = quote_spanned!(source.span()=> self.#source #asref.as_dyn_error());
         Some(quote! {
-            std::option::Option::Some(#dyn_error)
+            ::core::option::Option::Some(#dyn_error)
         })
     } else {
         None
     };
     let source_method = source_body.map(|body| {
         quote! {
-            fn source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)> {
+            fn source(&self) -> ::core::option::Option<&(dyn std::error::Error + 'static)> {
                 use thiserror::__private::AsDynError;
                 #body
             }
@@ -66,7 +66,7 @@ fn impl_struct(input: Struct) -> TokenStream {
             let source = &source_field.member;
             let source_provide = if type_is_option(source_field.ty) {
                 quote_spanned! {source.span()=>
-                    if let std::option::Option::Some(source) = &self.#source {
+                    if let ::core::option::Option::Some(source) = &self.#source {
                         source.thiserror_provide(#request);
                     }
                 }
@@ -79,7 +79,7 @@ fn impl_struct(input: Struct) -> TokenStream {
                 None
             } else if type_is_option(backtrace_field.ty) {
                 Some(quote! {
-                    if let std::option::Option::Some(backtrace) = &self.#backtrace {
+                    if let ::core::option::Option::Some(backtrace) = &self.#backtrace {
                         #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
                     }
                 })
@@ -95,7 +95,7 @@ fn impl_struct(input: Struct) -> TokenStream {
             }
         } else if type_is_option(backtrace_field.ty) {
             quote! {
-                if let std::option::Option::Some(backtrace) = &self.#backtrace {
+                if let ::core::option::Option::Some(backtrace) = &self.#backtrace {
                     #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
                 }
             }
@@ -116,7 +116,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         let only_field = &input.fields[0].member;
         display_implied_bounds.insert((0, Trait::Display));
         Some(quote! {
-            std::fmt::Display::fmt(&self.#only_field, __formatter)
+            ::core::fmt::Display::fmt(&self.#only_field, __formatter)
         })
     } else if let Some(display) = &input.attrs.display {
         display_implied_bounds = display.implied_bounds.clone();
@@ -142,9 +142,9 @@ fn impl_struct(input: Struct) -> TokenStream {
         let display_where_clause = display_inferred_bounds.augment_where_clause(input.generics);
         quote! {
             #[allow(unused_qualifications)]
-            impl #impl_generics std::fmt::Display for #ty #ty_generics #display_where_clause {
+            impl #impl_generics ::core::fmt::Display for #ty #ty_generics #display_where_clause {
                 #[allow(clippy::used_underscore_binding)]
-                fn fmt(&self, __formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                fn fmt(&self, __formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #body
                 }
             }
@@ -157,7 +157,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         let body = from_initializer(from_field, backtrace_field);
         quote! {
             #[allow(unused_qualifications)]
-            impl #impl_generics std::convert::From<#from> for #ty #ty_generics #where_clause {
+            impl #impl_generics ::core::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
                 fn from(source: #from) -> Self {
                     #ty #body
@@ -217,16 +217,16 @@ fn impl_enum(input: Enum) -> TokenStream {
                 let varsource = quote!(source);
                 let dyn_error = quote_spanned!(source.span()=> #varsource #asref.as_dyn_error());
                 quote! {
-                    #ty::#ident {#source: #varsource, ..} => std::option::Option::Some(#dyn_error),
+                    #ty::#ident {#source: #varsource, ..} => ::core::option::Option::Some(#dyn_error),
                 }
             } else {
                 quote! {
-                    #ty::#ident {..} => std::option::Option::None,
+                    #ty::#ident {..} => ::core::option::Option::None,
                 }
             }
         });
         Some(quote! {
-            fn source(&self) -> std::option::Option<&(dyn std::error::Error + 'static)> {
+            fn source(&self) -> ::core::option::Option<&(dyn std::error::Error + 'static)> {
                 use thiserror::__private::AsDynError;
                 #[allow(deprecated)]
                 match self {
@@ -251,7 +251,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let varsource = quote!(source);
                     let source_provide = if type_is_option(source_field.ty) {
                         quote_spanned! {source.span()=>
-                            if let std::option::Option::Some(source) = #varsource {
+                            if let ::core::option::Option::Some(source) = #varsource {
                                 source.thiserror_provide(#request);
                             }
                         }
@@ -262,7 +262,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                     };
                     let self_provide = if type_is_option(backtrace_field.ty) {
                         quote! {
-                            if let std::option::Option::Some(backtrace) = backtrace {
+                            if let ::core::option::Option::Some(backtrace) = backtrace {
                                 #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
                             }
                         }
@@ -290,7 +290,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let varsource = quote!(source);
                     let source_provide = if type_is_option(source_field.ty) {
                         quote_spanned! {backtrace.span()=>
-                            if let std::option::Option::Some(source) = #varsource {
+                            if let ::core::option::Option::Some(source) = #varsource {
                                 source.thiserror_provide(#request);
                             }
                         }
@@ -310,7 +310,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let backtrace = &backtrace_field.member;
                     let body = if type_is_option(backtrace_field.ty) {
                         quote! {
-                            if let std::option::Option::Some(backtrace) = backtrace {
+                            if let ::core::option::Option::Some(backtrace) = backtrace {
                                 #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
                             }
                         }
@@ -369,7 +369,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                         Member::Unnamed(index) => format_ident!("_{}", index),
                     };
                     display_implied_bounds.insert((0, Trait::Display));
-                    quote!(std::fmt::Display::fmt(#only_field, __formatter))
+                    quote!(::core::fmt::Display::fmt(#only_field, __formatter))
                 }
             };
             for (field, bound) in display_implied_bounds {
@@ -388,8 +388,8 @@ fn impl_enum(input: Enum) -> TokenStream {
         let display_where_clause = display_inferred_bounds.augment_where_clause(input.generics);
         Some(quote! {
             #[allow(unused_qualifications)]
-            impl #impl_generics std::fmt::Display for #ty #ty_generics #display_where_clause {
-                fn fmt(&self, __formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            impl #impl_generics ::core::fmt::Display for #ty #ty_generics #display_where_clause {
+                fn fmt(&self, __formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #use_as_display
                     #[allow(unused_variables, deprecated, clippy::used_underscore_binding)]
                     match #void_deref self {
@@ -410,7 +410,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         let body = from_initializer(from_field, backtrace_field);
         Some(quote! {
             #[allow(unused_qualifications)]
-            impl #impl_generics std::convert::From<#from> for #ty #ty_generics #where_clause {
+            impl #impl_generics ::core::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
                 fn from(source: #from) -> Self {
                     #ty::#variant #body
@@ -466,7 +466,7 @@ fn use_as_display(needs_as_display: bool) -> Option<TokenStream> {
 fn from_initializer(from_field: &Field, backtrace_field: Option<&Field>) -> TokenStream {
     let from_member = &from_field.member;
     let some_source = if type_is_option(from_field.ty) {
-        quote!(std::option::Option::Some(source))
+        quote!(::core::option::Option::Some(source))
     } else {
         quote!(source)
     };
@@ -474,11 +474,11 @@ fn from_initializer(from_field: &Field, backtrace_field: Option<&Field>) -> Toke
         let backtrace_member = &backtrace_field.member;
         if type_is_option(backtrace_field.ty) {
             quote! {
-                #backtrace_member: std::option::Option::Some(std::backtrace::Backtrace::capture()),
+                #backtrace_member: ::core::option::Option::Some(::std::backtrace::Backtrace::capture()),
             }
         } else {
             quote! {
-                #backtrace_member: std::convert::From::from(std::backtrace::Backtrace::capture()),
+                #backtrace_member: ::core::convert::From::from(::std::backtrace::Backtrace::capture()),
             }
         }
     });


### PR DESCRIPTION
Prefer using core crate over std in macro expansions wherever a symbol has
a stable equivalent in core.  This makes it easier to eventually support
no_std in the future once error_in_core stabilises.
