### PR TITLE
Change span of `as_dyn_error()` to point compile error at attribute.

### DIFF
--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -1,5 +1,6 @@
 use crate::ast::{Enum, Field, Struct, Variant};
-use syn::{Member, Type};
+use proc_macro2::Span;
+use syn::{spanned::Spanned, Member, Type};
 
 impl Struct<'_> {
     pub(crate) fn from_field(&self) -> Option<&Field> {
@@ -69,6 +70,16 @@ impl Variant<'_> {
 impl Field<'_> {
     pub(crate) fn is_backtrace(&self) -> bool {
         type_is_backtrace(self.ty)
+    }
+
+    pub(crate) fn source_span(&self) -> Span {
+        if let Some(source_attr) = &self.attrs.source {
+            source_attr.path().span()
+        } else if let Some(from_attr) = &self.attrs.from {
+            from_attr.path().span()
+        } else {
+            self.member.span()
+        }
     }
 }
 

--- a/tests/ui/source-enum-unnamed-field-not-error.rs
+++ b/tests/ui/source-enum-unnamed-field-not-error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct NotError;
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub enum ErrorEnum {
+    Broken(#[source] NotError),
+}
+
+fn main() {}

--- a/tests/ui/source-enum-unnamed-field-not-error.stderr
+++ b/tests/ui/source-enum-unnamed-field-not-error.stderr
@@ -1,0 +1,22 @@
+error[E0599]: the method `as_dyn_error` exists for reference `&NotError`, but its trait bounds were not satisfied
+ --> tests/ui/source-enum-unnamed-field-not-error.rs:9:14
+  |
+4 | pub struct NotError;
+  | -------------------
+  | |
+  | doesn't satisfy `NotError: AsDynError<'_>`
+  | doesn't satisfy `NotError: std::error::Error`
+...
+9 |     Broken(#[source] NotError),
+  |              ^^^^^^ method cannot be called on `&NotError` due to unsatisfied trait bounds
+  |
+  = note: the following trait bounds were not satisfied:
+          `NotError: std::error::Error`
+          which is required by `NotError: AsDynError<'_>`
+          `&NotError: std::error::Error`
+          which is required by `&NotError: AsDynError<'_>`
+note: the trait `std::error::Error` must be implemented
+ --> $RUST/core/src/error.rs
+  |
+  | pub trait Error: Debug + Display {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/source-struct-unnamed-field-not-error.rs
+++ b/tests/ui/source-struct-unnamed-field-not-error.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+#[derive(Debug)]
+struct NotError;
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub struct ErrorStruct(#[source] NotError);
+
+fn main() {}

--- a/tests/ui/source-struct-unnamed-field-not-error.stderr
+++ b/tests/ui/source-struct-unnamed-field-not-error.stderr
@@ -1,0 +1,21 @@
+error[E0599]: the method `as_dyn_error` exists for struct `NotError`, but its trait bounds were not satisfied
+ --> tests/ui/source-struct-unnamed-field-not-error.rs:8:26
+  |
+4 | struct NotError;
+  | ---------------
+  | |
+  | method `as_dyn_error` not found for this struct
+  | doesn't satisfy `NotError: AsDynError<'_>`
+  | doesn't satisfy `NotError: std::error::Error`
+...
+8 | pub struct ErrorStruct(#[source] NotError);
+  |                          ^^^^^^ method cannot be called on `NotError` due to unsatisfied trait bounds
+  |
+  = note: the following trait bounds were not satisfied:
+          `NotError: std::error::Error`
+          which is required by `NotError: AsDynError<'_>`
+note: the trait `std::error::Error` must be implemented
+ --> $RUST/core/src/error.rs
+  |
+  | pub trait Error: Debug + Display {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/transparent-enum-not-error.rs
+++ b/tests/ui/transparent-enum-not-error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Other {
+        message: String,
+    }
+}
+
+fn main() {}

--- a/tests/ui/transparent-enum-not-error.stderr
+++ b/tests/ui/transparent-enum-not-error.stderr
@@ -1,0 +1,23 @@
+error[E0599]: the method `as_dyn_error` exists for reference `&String`, but its trait bounds were not satisfied
+ --> tests/ui/transparent-enum-not-error.rs:5:13
+  |
+5 |     #[error(transparent)]
+  |             ^^^^^^^^^^^ method cannot be called on `&String` due to unsatisfied trait bounds
+  |
+ ::: $RUST/alloc/src/string.rs
+  |
+  | pub struct String {
+  | -----------------
+  | |
+  | doesn't satisfy `String: AsDynError<'_>`
+  | doesn't satisfy `String: std::error::Error`
+  |
+  = note: the following trait bounds were not satisfied:
+          `String: std::error::Error`
+          which is required by `String: AsDynError<'_>`
+          `&String: std::error::Error`
+          which is required by `&String: AsDynError<'_>`
+          `str: Sized`
+          which is required by `str: AsDynError<'_>`
+          `str: std::error::Error`
+          which is required by `str: AsDynError<'_>`

--- a/tests/ui/transparent-enum-unnamed-field-not-error.rs
+++ b/tests/ui/transparent-enum-unnamed-field-not-error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Other(String),
+}
+
+fn main() {}

--- a/tests/ui/transparent-enum-unnamed-field-not-error.stderr
+++ b/tests/ui/transparent-enum-unnamed-field-not-error.stderr
@@ -1,0 +1,23 @@
+error[E0599]: the method `as_dyn_error` exists for reference `&String`, but its trait bounds were not satisfied
+ --> tests/ui/transparent-enum-unnamed-field-not-error.rs:5:13
+  |
+5 |     #[error(transparent)]
+  |             ^^^^^^^^^^^ method cannot be called on `&String` due to unsatisfied trait bounds
+  |
+ ::: $RUST/alloc/src/string.rs
+  |
+  | pub struct String {
+  | -----------------
+  | |
+  | doesn't satisfy `String: AsDynError<'_>`
+  | doesn't satisfy `String: std::error::Error`
+  |
+  = note: the following trait bounds were not satisfied:
+          `String: std::error::Error`
+          which is required by `String: AsDynError<'_>`
+          `&String: std::error::Error`
+          which is required by `&String: AsDynError<'_>`
+          `str: Sized`
+          which is required by `str: AsDynError<'_>`
+          `str: std::error::Error`
+          which is required by `str: AsDynError<'_>`

--- a/tests/ui/transparent-struct-not-error.rs
+++ b/tests/ui/transparent-struct-not-error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct Error {
+    message: String,
+}
+
+fn main() {}

--- a/tests/ui/transparent-struct-not-error.stderr
+++ b/tests/ui/transparent-struct-not-error.stderr
@@ -1,0 +1,21 @@
+error[E0599]: the method `as_dyn_error` exists for struct `String`, but its trait bounds were not satisfied
+ --> tests/ui/transparent-struct-not-error.rs:4:9
+  |
+4 | #[error(transparent)]
+  |         ^^^^^^^^^^^ method cannot be called on `String` due to unsatisfied trait bounds
+  |
+ ::: $RUST/alloc/src/string.rs
+  |
+  | pub struct String {
+  | -----------------
+  | |
+  | doesn't satisfy `String: AsDynError<'_>`
+  | doesn't satisfy `String: std::error::Error`
+  |
+  = note: the following trait bounds were not satisfied:
+          `String: std::error::Error`
+          which is required by `String: AsDynError<'_>`
+          `str: Sized`
+          which is required by `str: AsDynError<'_>`
+          `str: std::error::Error`
+          which is required by `str: AsDynError<'_>`

--- a/tests/ui/transparent-struct-unnamed-field-not-error.rs
+++ b/tests/ui/transparent-struct-unnamed-field-not-error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct Error(String);
+
+fn main() {}

--- a/tests/ui/transparent-struct-unnamed-field-not-error.stderr
+++ b/tests/ui/transparent-struct-unnamed-field-not-error.stderr
@@ -1,0 +1,21 @@
+error[E0599]: the method `as_dyn_error` exists for struct `String`, but its trait bounds were not satisfied
+ --> tests/ui/transparent-struct-unnamed-field-not-error.rs:4:9
+  |
+4 | #[error(transparent)]
+  |         ^^^^^^^^^^^ method cannot be called on `String` due to unsatisfied trait bounds
+  |
+ ::: $RUST/alloc/src/string.rs
+  |
+  | pub struct String {
+  | -----------------
+  | |
+  | doesn't satisfy `String: AsDynError<'_>`
+  | doesn't satisfy `String: std::error::Error`
+  |
+  = note: the following trait bounds were not satisfied:
+          `String: std::error::Error`
+          which is required by `String: AsDynError<'_>`
+          `str: Sized`
+          which is required by `str: AsDynError<'_>`
+          `str: std::error::Error`
+          which is required by `str: AsDynError<'_>`


### PR DESCRIPTION
This PR changes the span of the `as_dyn_error()` call to the `#[source]`, `#[from]` or `#[transparant]` attribute if it exists.

My motivation was a (to me) confusing error that actually made me think `thiserror` had a bug:

```rust
use thiserror::Error;

#[derive(Debug, Error)]
#[error("{0}")]
enum Error {
    Io(#[from] std::io::Error),
    Custom(#[from] String),
}
```

![image](https://github.com/dtolnay/thiserror/assets/786213/d26f2dd3-5d2e-4b30-959c-d972aa2ab426)

The error uses the span of the source member, but in this case it is unnamed. How exactly it ends up with the span of the string literal is a bit unclear to me. Maybe because the member (`0`) is used in the formatting code?

Regardless, with this PR, the error is the same but the span is changed to the attribute:

![image](https://github.com/dtolnay/thiserror/assets/786213/4f70c905-84c4-43cf-95e0-f0d8188e1f38)

If there was no `#[source]`, `#[from]` or `#[transparent]` attribute, the member name is used as before (which in practise means it must be a member named `source`).
