### PR TITLE
Restore UI test involving missing Display impl

### DIFF
--- a/tests/ui/missing-display.rs
+++ b/tests/ui/missing-display.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MyError {
+    First,
+    Second,
+}
+
+fn main() {}

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -4,10 +4,10 @@ error[E0277]: `MyError` doesn't implement `std::fmt::Display`
 4  | pub enum MyError {
    | ^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
    |
-  ::: $RUST/std/src/error.rs
-   |
-   | pub trait Error: Debug + Display {
-   |                          ------- required by this bound in `std::error::Error`
-   |
    = help: the trait `std::fmt::Display` is not implemented for `MyError`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `std::error::Error`
+  --> $RUST/std/src/error.rs
+   |
+   | pub trait Error: Debug + Display {
+   |                          ^^^^^^^ required by this bound in `std::error::Error`

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `MyError` doesn't implement `std::fmt::Display`
-  --> tests/ui/missing-display.rs:4:1
+  --> tests/ui/missing-display.rs:4:10
    |
 4  | pub enum MyError {
-   | ^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
+   |          ^^^^^^^ `MyError` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `MyError`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -1,13 +1,13 @@
 error[E0277]: `MyError` doesn't implement `std::fmt::Display`
-  --> tests/ui/missing-display.rs:4:10
-   |
-4  | pub enum MyError {
-   |          ^^^^^^^ `MyError` cannot be formatted with the default formatter
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `MyError`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+ --> tests/ui/missing-display.rs:4:10
+  |
+4 | pub enum MyError {
+  |          ^^^^^^^ `MyError` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `MyError`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `std::error::Error`
-  --> $RUST/core/src/error.rs
-   |
-   | pub trait Error: Debug + Display {
-   |                          ^^^^^^^ required by this bound in `Error`
+ --> $RUST/core/src/error.rs
+  |
+  | pub trait Error: Debug + Display {
+  |                          ^^^^^^^ required by this bound in `Error`

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -7,7 +7,7 @@ error[E0277]: `MyError` doesn't implement `std::fmt::Display`
    = help: the trait `std::fmt::Display` is not implemented for `MyError`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `std::error::Error`
-  --> $RUST/std/src/error.rs
+  --> $RUST/core/src/error.rs
    |
    | pub trait Error: Debug + Display {
    |                          ^^^^^^^ required by this bound in `std::error::Error`

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -4,7 +4,7 @@ error[E0277]: `MyError` doesn't implement `std::fmt::Display`
 4  | pub enum MyError {
    | ^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
    |
-  ::: $RUST/src/libstd/error.rs
+  ::: $RUST/std/src/error.rs
    |
    | pub trait Error: Debug + Display {
    |                          ------- required by this bound in `std::error::Error`

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -10,4 +10,4 @@ note: required by a bound in `std::error::Error`
   --> $RUST/core/src/error.rs
    |
    | pub trait Error: Debug + Display {
-   |                          ^^^^^^^ required by this bound in `std::error::Error`
+   |                          ^^^^^^^ required by this bound in `Error`

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -1,0 +1,8 @@
+error[E0277]: `MyError` doesn't implement `std::fmt::Display`
+  --> tests/ui/missing-display.rs:4:1
+   |
+4  | pub enum MyError {
+   | ^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `MyError`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead

--- a/tests/ui/missing-display.stderr
+++ b/tests/ui/missing-display.stderr
@@ -4,5 +4,10 @@ error[E0277]: `MyError` doesn't implement `std::fmt::Display`
 4  | pub enum MyError {
    | ^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
    |
+  ::: $RUST/src/libstd/error.rs
+   |
+   | pub trait Error: Debug + Display {
+   |                          ------- required by this bound in `std::error::Error`
+   |
    = help: the trait `std::fmt::Display` is not implemented for `MyError`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead


### PR DESCRIPTION
This test existed prior to 04b91d76462834279a323b7771b48158aba19db4.

Since 791a98eb93e08f111bd16d7ec73caf50f7225f31, we can rely on rust-src being installed.