### PR TITLE
Delete elaborate spans on path of error trait

### DIFF
--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -12,7 +12,6 @@ pub enum Input<'a> {
 }
 
 pub struct Struct<'a> {
-    pub original: &'a DeriveInput,
     pub attrs: Attrs<'a>,
     pub ident: Ident,
     pub generics: &'a Generics,
@@ -20,7 +19,6 @@ pub struct Struct<'a> {
 }
 
 pub struct Enum<'a> {
-    pub original: &'a DeriveInput,
     pub attrs: Attrs<'a>,
     pub ident: Ident,
     pub generics: &'a Generics,
@@ -65,7 +63,6 @@ impl<'a> Struct<'a> {
             display.expand_shorthand(&fields);
         }
         Ok(Struct {
-            original: node,
             attrs,
             ident: node.ident.clone(),
             generics: &node.generics,
@@ -96,7 +93,6 @@ impl<'a> Enum<'a> {
             })
             .collect::<Result<_>>()?;
         Ok(Enum {
-            original: node,
             attrs,
             ident: node.ident.clone(),
             generics: &node.generics,


### PR DESCRIPTION
#76 shows that this used to be required in order to create a good error message, on older compilers.

From #263 it's clear that this no longer makes a difference in new compilers.