### PR TITLE
Typecheck backtrace fields even if no generic member access

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -141,8 +141,10 @@ fn impl_struct(input: Struct) -> TokenStream {
             }
         };
         quote! {
-            fn provide<'_request>(&'_request self, #request: &mut std::error::Request<'_request>) {
-                #body
+            thiserror::__if_generic_member_access! {
+                fn provide<'_request>(&'_request self, #request: &mut std::error::Request<'_request>) {
+                    #body
+                }
             }
         }
     });
@@ -370,10 +372,12 @@ fn impl_enum(input: Enum) -> TokenStream {
             }
         });
         Some(quote! {
-            fn provide<'_request>(&'_request self, #request: &mut std::error::Request<'_request>) {
-                #[allow(deprecated)]
-                match self {
-                    #(#arms)*
+            thiserror::__if_generic_member_access! {
+                fn provide<'_request>(&'_request self, #request: &mut std::error::Request<'_request>) {
+                    #[allow(deprecated)]
+                    match self {
+                        #(#arms)*
+                    }
                 }
             }
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,4 +254,36 @@ pub mod __private {
     #[cfg(error_generic_member_access)]
     #[doc(hidden)]
     pub use crate::provide::ThiserrorProvide;
+
+    #[cfg(error_generic_member_access)]
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! __if_generic_member_access {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
+
+    #[cfg(not(error_generic_member_access))]
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! __if_generic_member_access {
+        ($($tt:tt)*) => {};
+    }
+
+    #[cfg(not(error_generic_member_access))]
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! __if_no_generic_member_access {
+        ($($tt:tt)*) => {
+            $($tt)*
+        };
+    }
+
+    #[cfg(error_generic_member_access)]
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! __if_no_generic_member_access {
+        ($($tt:tt)*) => {};
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,4 +286,8 @@ pub mod __private {
     macro_rules! __if_no_generic_member_access {
         ($($tt:tt)*) => {};
     }
+
+    #[cfg(not(thiserror_no_backtrace))]
+    #[doc(hidden)]
+    pub fn typecheck_backtrace(_: &std::backtrace::Backtrace) {}
 }


### PR DESCRIPTION
Followup to https://github.com/dtolnay/thiserror/pull/223#pullrequestreview-1578014905. But I realized this is still problematic because code like the following:

```rust
// src/lib.rs

#[derive(thiserror::Error, Debug)]
#[error("...")]
pub struct Error {
    backtrace: std::backtrace::Backtrace,
}
```

would require the downstream code to do their own conditional compilation to decide whether to insert `#![feature(error_generic_member_access)]` in the crate root or not. It isn't enough for thiserror to conditionally produce `fn provide` only on nightly.

In this PR, thiserror would be expanding the above to:

```rust
// (on stable)
#[allow(unused_qualifications)]
impl std::error::Error for Error {
    fn source(&self) -> ::core::option::Option<&(dyn std::error::Error + 'static)> {
        thiserror::__private::typecheck_backtrace(&self.backtrace);
        ::core::option::Option::None
    }
}
#[allow(unused_qualifications)]
impl ::core::fmt::Display for Error {
    #[allow(clippy::used_underscore_binding)]
    fn fmt(&self, __formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
        #[allow(unused_variables, deprecated)]
        let Self { backtrace } = self;
        __formatter.write_fmt(format_args!("..."))
    }
}

// (on nightly)
#[allow(unused_qualifications)]
impl std::error::Error for Error {
    fn source(&self) -> ::core::option::Option<&(dyn std::error::Error + 'static)> {
        ::core::option::Option::None
    }
    fn provide<'_request>(
        &'_request self,
        request: &mut std::error::Request<'_request>,
    ) {
        request.provide_ref::<std::backtrace::Backtrace>(&self.backtrace);
    }
}
#[allow(unused_qualifications)]
impl ::core::fmt::Display for Error {
    #[allow(clippy::used_underscore_binding)]
    fn fmt(&self, __formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
        #[allow(unused_variables, deprecated)]
        let Self { backtrace } = self;
        __formatter.write_fmt(format_args!("..."))
    }
}
```