### PR TITLE
Rerun build script on RUSTC_BOOTSTRAP change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,6 +38,8 @@ const PROBE: &str = r#"
 "#;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=RUSTC_BOOTSTRAP");
+
     match compile_probe() {
         Some(status) if status.success() => println!("cargo:rustc-cfg=error_generic_member_access"),
         _ => {}


### PR DESCRIPTION
Example failure mode without this PR:

```rust
#![feature(error_generic_member_access)]

#[derive(thiserror::Error, Debug)]
#[error("...")]
pub struct Error {
    #[backtrace]
    source: std::io::Error,
}
```

```console
$ cargo +stable check  #(expected failure)
   Compiling proc-macro2 v1.0.71
   Compiling unicode-ident v1.0.12
   Compiling thiserror v1.0.51
   Compiling quote v1.0.33
   Compiling syn v2.0.43
   Compiling thiserror-impl v1.0.51
    Checking repro v0.0.0
error[E0432]: unresolved import `thiserror`
   --> src/lib.rs:3:10
    |
3   | #[derive(thiserror::Error, Debug)]
    |          ^^^^^^^^^^^^^^^^ no `ThiserrorProvide` in `__private`
    |
note: found an item that was configured out
   --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/thiserror-1.0.51/src/lib.rs:256:29
    |
256 |     pub use crate::provide::ThiserrorProvide;
    |                             ^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `thiserror::Error` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0554]: `#![feature]` may not be used on the stable release channel
 --> src/lib.rs:1:12
  |
1 | #![feature(error_generic_member_access)]
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0599]: no method named `thiserror_provide` found for struct `std::io::Error` in the current scope
 --> src/lib.rs:7:5
  |
7 |     source: std::io::Error,
  |     ^^^^^^ method not found in `Error`

Some errors have detailed explanations: E0432, E0554, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `repro` due to 3 previous errors
```

```console
$ RUSTC_BOOTSTRAP=1 cargo +stable check  #(should work, but doesn't)
    Checking repro v0.0.0
error[E0432]: unresolved import `thiserror`
   --> src/lib.rs:3:10
    |
3   | #[derive(thiserror::Error, Debug)]
    |          ^^^^^^^^^^^^^^^^ no `ThiserrorProvide` in `__private`
    |
note: found an item that was configured out
   --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/thiserror-1.0.51/src/lib.rs:256:29
    |
256 |     pub use crate::provide::ThiserrorProvide;
    |                             ^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `thiserror::Error` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `thiserror_provide` found for struct `std::io::Error` in the current scope
 --> src/lib.rs:7:5
  |
7 |     source: std::io::Error,
  |     ^^^^^^ method not found in `Error`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `repro` due to 2 previous errors
```

```console
$ cargo +stable clean
     Removed 242 files, 46.6MiB total
$ RUSTC_BOOTSTRAP=1 cargo +stable check  #(same as previous build, but now works)
   Compiling proc-macro2 v1.0.71
   Compiling unicode-ident v1.0.12
   Compiling thiserror v1.0.51
   Compiling quote v1.0.33
   Compiling syn v2.0.43
   Compiling thiserror-impl v1.0.51
    Checking repro v0.0.0
    Finished dev [unoptimized + debuginfo] target(s) in 3.23s
```

After this PR: `RUSTC_BOOTSTRAP=1 cargo +stable check` works the first time.