### PR TITLE
Remove option_if_let_else clippy suppression

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -8,7 +8,6 @@
     clippy::map_unwrap_or,
     clippy::module_name_repetitions,
     clippy::needless_pass_by_value,
-    clippy::option_if_let_else,
     clippy::range_plus_one,
     clippy::single_match_else,
     clippy::struct_field_names,

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -1,8 +1,4 @@
-#![allow(
-    clippy::iter_cloned_collect,
-    clippy::option_if_let_else,
-    clippy::uninlined_format_args
-)]
+#![allow(clippy::iter_cloned_collect, clippy::uninlined_format_args)]
 
 use std::fmt::Display;
 use thiserror::Error;


### PR DESCRIPTION
This lint got downgraded from `pedantic` to `nursery` by https://github.com/rust-lang/rust-clippy/pull/7568 so we no longer run it.