### PR TITLE
Make env-dep:RUSTC_BOOTSTRAP get listed in probe's dep-info

### DIFF
--- a/build/probe.rs
+++ b/build/probe.rs
@@ -27,3 +27,6 @@ impl Error for MyError {
         request.provide_ref(&self.0);
     }
 }
+
+// Include in sccache cache key.
+const _: Option<&str> = option_env!("RUSTC_BOOTSTRAP");


### PR DESCRIPTION
I expect that this fixes #278.

Sccache looks at dep-info (the thing produced by `--emit=dep-info`) to decide what environment variables to hash into the cache key for a particular compilation. See https://github.com/mozilla/sccache/blob/v0.7.4/src/compiler/rust.rs#L1424-L1448.

```rust
// 7. Environment variables: Hash all environment variables listed in the rustc dep-info
//    output. Additionally also has all environment variables starting with `CARGO_`,
//    since those are not listed in dep-info but affect cacheability.
```

Without this PR, the following failure mode explains the symptom of #278:

1. Cargo or something else compiles thiserror with a stable compiler and RUSTC_BOOTSTRAP **set**. (Apparently RustRover likes to do this. https://youtrack.jetbrains.com/issue/RUST-13133)
2. The build script compiles probe.rs with RUSTC_BOOTSTRAP **unset**. This fails, and the failure is not cached by sccache.
3. The build script compiles probe.rs with RUSTC_BOOTSTRAP **set**. This succeeds and is cached by sccache, but RUSTC_BOOTSTRAP is incorrectly absent from the cache key.
4. In some other shell, Cargo or something else compiles thiserror with a stable compiler and RUSTC_BOOTSTRAP **unset**.
5. The build script compiles probe.rs with RUSTC_BOOTSTRAP **unset** and sccache feeds it the improperly cached successful result from step 3, so build script thinks it compiled successfully, even though it should not have. Chaos.