### PR TITLE
Emit dep-info for probe.rs in case sccache needs it

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -84,7 +84,7 @@ fn compile_probe(rustc_bootstrap: bool) -> bool {
         .arg("--edition=2018")
         .arg("--crate-name=thiserror")
         .arg("--crate-type=lib")
-        .arg("--emit=metadata")
+        .arg("--emit=dep-info,metadata")
         .arg("--out-dir")
         .arg(out_dir)
         .arg(probefile);


### PR DESCRIPTION
This may or may not also be necessary for #278, in addition to #279. I am not sure whether sccache will add `--emit=dep-info` itself if not already present, or if it has a way of reconstructing dep-info from an rmeta output.