### PR TITLE
Make compatible with -Dwarnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -84,6 +84,7 @@ fn compile_probe(rustc_bootstrap: bool) -> bool {
         .arg("--edition=2018")
         .arg("--crate-name=thiserror")
         .arg("--crate-type=lib")
+        .arg("--cap-lints=allow")
         .arg("--emit=dep-info,metadata")
         .arg("--out-dir")
         .arg(out_dir)


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/121752 in nightly-2024-03-12, rustc reports the following pair of dead_code warnings in build/probe.rs, which makes it look as though error_generic_member_access is not available when using `RUSTFLAGS=-Dwarnings` (such as in CI).

```console
warning: struct `MyError` is never constructed
  --> build/probe.rs:10:8
   |
10 | struct MyError(Thing);
   |        ^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: struct `Thing` is never constructed
  --> build/probe.rs:11:8
   |
11 | struct Thing;
   |        ^^^^^
```