### PR TITLE
Separate Error and Display derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/thiserror"
 rust-version = "1.56"
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 thiserror-impl = { version = "=1.0.58", path = "impl" }
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -32,5 +32,11 @@ use syn::{parse_macro_input, DeriveInput};
 #[proc_macro_derive(Error, attributes(backtrace, error, from, source))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    expand::derive(&input).into()
+    expand::derive(&input, expand::DeriveType::Error).into()
+}
+
+#[proc_macro_derive(Display, attributes(backtrace, error, from, source))]
+pub fn derive_display(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand::derive(&input, expand::DeriveType::Display).into()
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,4 +1,5 @@
-use std::fmt::Display;
+use core::fmt::Display;
+#[cfg(feature = "std")]
 use std::path::{self, Path, PathBuf};
 
 #[doc(hidden)]
@@ -21,6 +22,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> AsDisplay<'a> for Path {
     type Target = path::Display<'a>;
 
@@ -30,6 +32,7 @@ impl<'a> AsDisplay<'a> for Path {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> AsDisplay<'a> for PathBuf {
     type Target = path::Display<'a>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,7 @@
 //!
 //!   [`anyhow`]: https://github.com/dtolnay/anyhow
 
+#![no_std]
 #![doc(html_root_url = "https://docs.rs/thiserror/1.0.58")]
 #![allow(
     clippy::module_name_repetitions,
@@ -240,9 +241,13 @@
 #[cfg(all(thiserror_nightly_testing, not(error_generic_member_access)))]
 compile_error!("Build script probe failed to compile.");
 
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
 mod aserror;
 mod display;
-#[cfg(error_generic_member_access)]
+#[cfg(all(error_generic_member_access, feature = "std"))]
 mod provide;
 
 pub use thiserror_impl::*;
@@ -250,11 +255,12 @@ pub use thiserror_impl::*;
 // Not public API.
 #[doc(hidden)]
 pub mod __private {
+    #[cfg(feature = "std")]
     #[doc(hidden)]
     pub use crate::aserror::AsDynError;
     #[doc(hidden)]
     pub use crate::display::AsDisplay;
-    #[cfg(error_generic_member_access)]
+    #[cfg(all(error_generic_member_access, feature = "std"))]
     #[doc(hidden)]
     pub use crate::provide::ThiserrorProvide;
 }


### PR DESCRIPTION
I was faced with the same as this issue: https://github.com/dtolnay/thiserror/issues/250

I have a `no_std` project but I want to use both the `Display` and `From` implementations from this crate.

This is still a work in progress, pending:

- [ ] Add / update documentation
- [ ] Some attributes do nothing for `Display` (e.g. `source`) so this should give an error?

Would there be any opposition for such a change? As per commented in the linked issue, this could be a nice to have until stabilization of `error_in_core`.