### PR TITLE
`std::fmt` -> `core::fmt`

### DIFF
--- a/build/probe.rs
+++ b/build/probe.rs
@@ -5,7 +5,7 @@
 #![feature(error_generic_member_access)]
 
 use std::error::{Error, Request};
-use std::fmt::{self, Debug, Display};
+use core::fmt::{self, Debug, Display};
 
 struct MyError(Thing);
 struct Thing;

--- a/src/aserror.rs
+++ b/src/aserror.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use std::panic::UnwindSafe;
+use core::panic::UnwindSafe;
 
 #[doc(hidden)]
 pub trait AsDynError<'a>: Sealed {

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use core::fmt::Display;
 use std::path::{self, Path, PathBuf};
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //!   which may be arbitrary expressions. For example:
 //!
 //!   ```rust
-//!   # use std::i32;
+//!   # use core::i32;
 //!   # use thiserror::Error;
 //!   #
 //!   #[derive(Error, Debug)]
@@ -129,7 +129,7 @@
 //!   std::error::Error` will work as a source.
 //!
 //!   ```rust
-//!   # use std::fmt::{self, Display};
+//!   # use core::fmt::{self, Display};
 //!   # use thiserror::Error;
 //!   #
 //!   #[derive(Error, Debug)]

--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::needless_raw_string_hashes, clippy::uninlined_format_args)]
 
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
 use thiserror::Error;
 
 fn assert<T: Display>(expected: &str, value: T) {

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
 use std::io;
 use thiserror::Error;
 

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::iter_cloned_collect, clippy::uninlined_format_args)]
 
-use std::fmt::Display;
+use core::fmt::Display;
 use thiserror::Error;
 
 // Some of the elaborate cases from the rcc codebase, which is a C compiler in

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::needless_late_init, clippy::uninlined_format_args)]
 
-use std::fmt::{self, Debug, Display};
+use core::fmt::{self, Debug, Display};
 use thiserror::Error;
 
 pub struct NoFormat;

--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -1,5 +1,5 @@
+use core::fmt::Display;
 use ref_cast::RefCast;
-use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 

--- a/tests/ui/fallback-impl-with-display.rs
+++ b/tests/ui/fallback-impl-with-display.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/tests/ui/lifetime.rs
+++ b/tests/ui/lifetime.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 use thiserror::Error;
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
This changes usage of `std::fmt` to `core::fmt` in the main crate.

The corresponding change in the derive macro crate was in #255 .

This simplifies adding support for `no_std` once `error_in_core` becomes stable.

Also changes the single use of `{std -> core}::panic::UnwindSafe`.
