### PR TITLE
Mark `#[automatically_derived]` for generated impls

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -36,6 +36,7 @@ fn fallback(input: &DeriveInput, error: syn::Error) -> TokenStream {
         #error
 
         #[allow(unused_qualifications)]
+        #[automatically_derived]
         impl #impl_generics std::error::Error for #ty #ty_generics #where_clause
         where
             // Work around trivial bounds being unstable.
@@ -44,6 +45,7 @@ fn fallback(input: &DeriveInput, error: syn::Error) -> TokenStream {
         {}
 
         #[allow(unused_qualifications)]
+        #[automatically_derived]
         impl #impl_generics ::core::fmt::Display for #ty #ty_generics #where_clause {
             fn fmt(&self, __formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 ::core::unreachable!()
@@ -178,6 +180,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         let display_where_clause = display_inferred_bounds.augment_where_clause(input.generics);
         quote! {
             #[allow(unused_qualifications)]
+            #[automatically_derived]
             impl #impl_generics ::core::fmt::Display for #ty #ty_generics #display_where_clause {
                 #[allow(clippy::used_underscore_binding)]
                 fn fmt(&self, __formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
@@ -193,6 +196,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         let body = from_initializer(from_field, backtrace_field);
         quote! {
             #[allow(unused_qualifications)]
+            #[automatically_derived]
             impl #impl_generics ::core::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
                 fn from(source: #from) -> Self {
@@ -211,6 +215,7 @@ fn impl_struct(input: Struct) -> TokenStream {
 
     quote! {
         #[allow(unused_qualifications)]
+        #[automatically_derived]
         impl #impl_generics std::error::Error for #ty #ty_generics #error_where_clause {
             #source_method
             #provide_method
@@ -427,6 +432,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         let display_where_clause = display_inferred_bounds.augment_where_clause(input.generics);
         Some(quote! {
             #[allow(unused_qualifications)]
+            #[automatically_derived]
             impl #impl_generics ::core::fmt::Display for #ty #ty_generics #display_where_clause {
                 fn fmt(&self, __formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #use_as_display
@@ -449,6 +455,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         let body = from_initializer(from_field, backtrace_field);
         Some(quote! {
             #[allow(unused_qualifications)]
+            #[automatically_derived]
             impl #impl_generics ::core::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
                 fn from(source: #from) -> Self {
@@ -467,6 +474,7 @@ fn impl_enum(input: Enum) -> TokenStream {
 
     quote! {
         #[allow(unused_qualifications)]
+        #[automatically_derived]
         impl #impl_generics std::error::Error for #ty #ty_generics #error_where_clause {
             #source_method
             #provide_method


### PR DESCRIPTION
Because
1. They are indeed automatically derived.
2. It does not break MSRV 1.56.
3. Avoid testing `Display` and `Error` methods (and each branches inside them) for test coverage. https://github.com/rust-lang/rust/pull/120185