### PR TITLE
Seal the private AsDisplay trait

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -2,7 +2,7 @@ use core::fmt::Display;
 use std::path::{self, Path, PathBuf};
 
 #[doc(hidden)]
-pub trait AsDisplay<'a> {
+pub trait AsDisplay<'a>: Sealed {
     // TODO: convert to generic associated type.
     // https://github.com/dtolnay/thiserror/pull/253
     type Target: Display;
@@ -38,3 +38,9 @@ impl<'a> AsDisplay<'a> for PathBuf {
         self.display()
     }
 }
+
+#[doc(hidden)]
+pub trait Sealed {}
+impl<T: Display> Sealed for &T {}
+impl Sealed for Path {}
+impl Sealed for PathBuf {}


### PR DESCRIPTION
The other 2 thiserror-internal helper traits are already sealed.

https://github.com/dtolnay/thiserror/blob/5088592a4efb6a5c40b4d869eb1a0e2eacf622cb/src/aserror.rs#L5

https://github.com/dtolnay/thiserror/blob/5088592a4efb6a5c40b4d869eb1a0e2eacf622cb/src/provide.rs#L4