### PR TITLE
Raise required compiler to rust 1.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.56.0]
+        rust: [nightly, beta, stable, 1.61.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.61.0]
+        rust: [nightly, beta, stable, 1.70.0, 1.61.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +39,7 @@ jobs:
         run: echo RUSTFLAGS=${RUSTFLAGS}\ --cfg=thiserror_nightly_testing >> $GITHUB_ENV
         if: matrix.rust == 'nightly'
       - run: cargo test --all
+        if: matrix.rust != '1.61.0'
       - uses: actions/upload-artifact@v4
         if: matrix.rust == 'nightly' && always()
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 keywords = ["error", "error-handling", "derive"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/thiserror"
-rust-version = "1.56"
+rust-version = "1.61"
 
 [dependencies]
 thiserror-impl = { version = "=1.0.65", path = "impl" }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This library provides a convenient derive macro for the standard library's
 thiserror = "1.0"
 ```
 
-*Compiler support: requires rustc 1.56+*
+*Compiler support: requires rustc 1.61+*
 
 <br>
 

--- a/build.rs
+++ b/build.rs
@@ -137,10 +137,7 @@ fn compile_probe(rustc_bootstrap: bool) -> bool {
 
 fn cargo_env_var(key: &str) -> OsString {
     env::var_os(key).unwrap_or_else(|| {
-        eprintln!(
-            "Environment variable ${} is not set during execution of build script",
-            key,
-        );
+        eprintln!("Environment variable ${key} is not set during execution of build script");
         process::exit(1);
     })
 }

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implementation detail of the `thiserror` crate"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/thiserror"
-rust-version = "1.56"
+rust-version = "1.61"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Required by recent versions of syn.