### PR TITLE
Add infallible expr scanner fallback for scanning invalid code

### DIFF
--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -119,6 +119,7 @@ impl Display<'_> {
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn explicit_named_args(input: ParseStream) -> Result<Set<Ident>> {
     let ahead = input.fork();
     if let Ok(set) = try_explicit_named_args(&ahead) {

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -1,10 +1,11 @@
 use crate::ast::Field;
 use crate::attr::{Display, Trait};
 use crate::scan_expr;
-use proc_macro2::TokenTree;
+use proc_macro2::{TokenStream, TokenTree};
 use quote::{format_ident, quote, quote_spanned};
 use std::collections::{BTreeSet as Set, HashMap as Map};
 use syn::ext::IdentExt;
+use syn::parse::discouraged::Speculative;
 use syn::parse::{ParseStream, Parser};
 use syn::{Expr, Ident, Index, LitStr, Member, Result, Token};
 
@@ -119,6 +120,23 @@ impl Display<'_> {
 }
 
 fn explicit_named_args(input: ParseStream) -> Result<Set<Ident>> {
+    let ahead = input.fork();
+    if let Ok(set) = try_explicit_named_args(&ahead) {
+        input.advance_to(&ahead);
+        return Ok(set);
+    }
+
+    let ahead = input.fork();
+    if let Ok(set) = fallback_explicit_named_args(&ahead) {
+        input.advance_to(&ahead);
+        return Ok(set);
+    }
+
+    input.parse::<TokenStream>().unwrap();
+    Ok(Set::new())
+}
+
+fn try_explicit_named_args(input: ParseStream) -> Result<Set<Ident>> {
     let scan_expr = if is_syn_full() {
         |input: ParseStream| input.parse::<Expr>().map(drop)
     } else {
@@ -138,6 +156,21 @@ fn explicit_named_args(input: ParseStream) -> Result<Set<Ident>> {
             named_args.insert(ident);
         }
         scan_expr(input)?;
+    }
+
+    Ok(named_args)
+}
+
+fn fallback_explicit_named_args(input: ParseStream) -> Result<Set<Ident>> {
+    let mut named_args = Set::new();
+
+    while !input.is_empty() {
+        if input.peek(Token![,]) && input.peek2(Ident::peek_any) && input.peek3(Token![=]) {
+            input.parse::<Token![,]>()?;
+            let ident = input.call(Ident::parse_any)?;
+            input.parse::<Token![=]>()?;
+            named_args.insert(ident);
+        }
     }
 
     Ok(named_args)


### PR DESCRIPTION
The infallible scanner has the same behavior as prior to https://github.com/dtolnay/thiserror/pull/337, which exhibits bugs like https://github.com/dtolnay/thiserror/issues/335 but that's okay because fallback is only going to be applied if the format arguments do not consist of syntactically valid expressions. This is useful for an IDE performing macro expansions while code is being typed.