### PR TITLE
Disregard equality binop in fallback parser

### DIFF
--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -184,7 +184,11 @@ fn fallback_explicit_named_args(input: ParseStream) -> Result<FmtArguments> {
     };
 
     while !input.is_empty() {
-        if input.peek(Token![,]) && input.peek2(Ident::peek_any) && input.peek3(Token![=]) {
+        if input.peek(Token![,])
+            && input.peek2(Ident::peek_any)
+            && input.peek3(Token![=])
+            && !input.peek3(Token![==])
+        {
             input.parse::<Token![,]>()?;
             let ident = input.call(Ident::parse_any)?;
             input.parse::<Token![=]>()?;


### PR DESCRIPTION
Previously an attribute containing both `==` and an incomplete expression, like `#[error("...", a == b, c = d +)]`, was treated incorrectly as containing 2 named fmt arguments `a` and `c`, instead of only `c`.