### PR TITLE
Add tests of `_` and `self` variables in format string

### DIFF
--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -319,6 +319,15 @@ fn test_keyword() {
 }
 
 #[test]
+fn test_self() {
+    #[derive(Error, Debug)]
+    #[error("error: {self:?}")]
+    struct Error;
+
+    assert("error: Error", Error);
+}
+
+#[test]
 fn test_str_special_chars() {
     #[derive(Error, Debug)]
     pub enum Error {

--- a/tests/ui/display-underscore.rs
+++ b/tests/ui/display-underscore.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("{_}")]
+pub struct Error;
+
+fn main() {}

--- a/tests/ui/display-underscore.stderr
+++ b/tests/ui/display-underscore.stderr
@@ -1,0 +1,7 @@
+error: invalid format string: invalid argument name `_`
+ --> tests/ui/display-underscore.rs:4:11
+  |
+4 | #[error("{_}")]
+  |           ^ invalid argument name in format string
+  |
+  = note: argument name cannot be a single underscore


### PR DESCRIPTION
Edge cases that came up as I am working on a fmt rewrite.