### PR TITLE
Delete support for raw identifiers inside format string

### DIFF
--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -279,7 +279,7 @@ fn test_macro_rules() {
 #[test]
 fn test_raw() {
     #[derive(Error, Debug)]
-    #[error("braced raw error: {r#fn}")]
+    #[error("braced raw error: {fn}")]
     struct Error {
         r#fn: &'static str,
     }
@@ -291,22 +291,11 @@ fn test_raw() {
 fn test_raw_enum() {
     #[derive(Error, Debug)]
     enum Error {
-        #[error("braced raw error: {r#fn}")]
+        #[error("braced raw error: {fn}")]
         Braced { r#fn: &'static str },
     }
 
     assert("braced raw error: T", Error::Braced { r#fn: "T" });
-}
-
-#[test]
-fn test_raw_conflict() {
-    #[derive(Error, Debug)]
-    enum Error {
-        #[error("braced raw error: {r#func}, {func}", func = "U")]
-        Braced { r#func: &'static str },
-    }
-
-    assert("braced raw error: T, U", Error::Braced { r#func: "T" });
 }
 
 #[test]

--- a/tests/ui/raw-identifier.rs
+++ b/tests/ui/raw-identifier.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("error: {r#fn}")]
+pub struct Error {
+    r#fn: &'static str,
+}
+
+fn main() {
+    let r#fn = "...";
+    let _ = format!("error: {r#fn}");
+}

--- a/tests/ui/raw-identifier.stderr
+++ b/tests/ui/raw-identifier.stderr
@@ -1,0 +1,21 @@
+error: invalid format string: raw identifiers are not supported
+ --> tests/ui/raw-identifier.rs:4:18
+  |
+4 | #[error("error: {r#fn}")]
+  |                  --^^
+  |                  |
+  |                  raw identifier used here in format string
+  |                  help: remove the `r#`
+  |
+  = note: identifiers in format strings can be keywords and don't need to be prefixed with `r#`
+
+error: invalid format string: raw identifiers are not supported
+  --> tests/ui/raw-identifier.rs:11:30
+   |
+11 |     let _ = format!("error: {r#fn}");
+   |                              --^^
+   |                              |
+   |                              raw identifier used here in format string
+   |                              help: remove the `r#`
+   |
+   = note: identifiers in format strings can be keywords and don't need to be prefixed with `r#`


### PR DESCRIPTION
`format_args!("{r#keyword}")` is not allowed by core::fmt's format string syntax. Thiserror shouldn't allow it either.