### PR TITLE
Add a type for representing raw-agnostic format vars

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -26,6 +26,7 @@ mod generics;
 mod prop;
 mod scan_expr;
 mod span;
+mod unraw;
 mod valid;
 
 use proc_macro::TokenStream;

--- a/impl/src/unraw.rs
+++ b/impl/src/unraw.rs
@@ -1,0 +1,67 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::ToTokens;
+use std::cmp::Ordering;
+use std::fmt::{self, Display};
+use syn::ext::IdentExt as _;
+use syn::parse::{Parse, ParseStream, Result};
+
+#[derive(Clone)]
+#[repr(transparent)]
+pub(crate) struct IdentUnraw(Ident);
+
+impl IdentUnraw {
+    pub fn new(ident: Ident) -> Self {
+        IdentUnraw(ident)
+    }
+
+    pub fn to_local(&self) -> Ident {
+        let unraw = self.0.unraw();
+        let repr = unraw.to_string();
+        if syn::parse_str::<Ident>(&repr).is_err() {
+            if let "_" | "super" | "self" | "Self" | "crate" = repr.as_str() {
+                // Some identifiers are never allowed to appear as raw, like r#self and r#_.
+            } else {
+                return Ident::new_raw(&repr, Span::call_site());
+            }
+        }
+        unraw
+    }
+}
+
+impl Display for IdentUnraw {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.0.unraw(), formatter)
+    }
+}
+
+impl Eq for IdentUnraw {}
+
+impl PartialEq for IdentUnraw {
+    fn eq(&self, other: &Self) -> bool {
+        PartialEq::eq(&self.0.unraw(), &other.0.unraw())
+    }
+}
+
+impl Ord for IdentUnraw {
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(&self.0.unraw(), &other.0.unraw())
+    }
+}
+
+impl PartialOrd for IdentUnraw {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(Self::cmp(self, other))
+    }
+}
+
+impl Parse for IdentUnraw {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.call(Ident::parse_any).map(IdentUnraw::new)
+    }
+}
+
+impl ToTokens for IdentUnraw {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.unraw().to_tokens(tokens);
+    }
+}


### PR DESCRIPTION
The core::fmt format string syntax considers `format_args!("...", r#keyword = "...")` as equivalent to `format_args!("...", keyword = "...")`. That means manipulating named argument sets as `Set<Ident>` using Ident's Ord impl doesn't make sense, as that impl considers `r#keyword` != `keyword`.

Before this PR, the following would compile successfully because thiserror would see that `fn` was already present in the user-provided named arguments, so it would not try to insert a new named argument referring to the struct field:

```rust
#[derive(Error, Debug)]
#[error("{fn}", fn = "...")]
pub struct Error {
    r#fn: &'static str,
}
```

But in contrast, the following would not compile, due to thiserror using an incorrect comparison and not realizing that a user-provided named argument for `{fn}` was already present.

```rust
#[derive(Error, Debug)]
#[error("{fn}", r#fn = "...")]
pub struct Error {
    r#fn: &'static str,
}
```

```console
error: duplicate argument named `r#fn`
 --> src/main.rs:4:9
  |
4 | #[error("{fn}", r#fn = "...")]
  |         ^^^^^^  ---- previously here
  |         |
  |         duplicate argument
```

After this PR, both compile.