### PR TITLE
Add test of r#source that is not Error::source

### DIFF
--- a/tests/test_source.rs
+++ b/tests/test_source.rs
@@ -63,3 +63,20 @@ error_from_macro! {
     #[error("Something")]
     Variant(#[from] io::Error)
 }
+
+#[test]
+fn test_not_source() {
+    #[derive(Error, Debug)]
+    #[error("{source} ==> {destination}")]
+    pub struct NotSource {
+        r#source: char,
+        destination: char,
+    }
+
+    let error = NotSource {
+        source: 'S',
+        destination: 'D',
+    };
+    assert_eq!(error.to_string(), "S ==> D");
+    assert!(error.source().is_none());
+}


### PR DESCRIPTION
Without `r#source`:

```console
error[E0599]: the method `as_dyn_error` exists for type `char`, but its trait bounds were not satisfied
  --> tests/test_source.rs:72:9
   |
72 |         source: char,
   |         ^^^^^^ method cannot be called on `char` due to unsatisfied trait bounds
   |
   = note: the following trait bounds were not satisfied:
           `char: std::error::Error`
           which is required by `char: AsDynError<'_>`
```