### PR TITLE
Add test of r#Backtrace that is not std::backtrace::Backtrace

### DIFF
--- a/tests/test_backtrace.rs
+++ b/tests/test_backtrace.rs
@@ -21,6 +21,11 @@ pub mod structs {
     use std::sync::Arc;
     use thiserror::Error;
 
+    mod not_backtrace {
+        #[derive(Debug)]
+        pub struct Backtrace;
+    }
+
     #[derive(Error, Debug)]
     #[error("...")]
     pub struct PlainBacktrace {
@@ -32,6 +37,12 @@ pub mod structs {
     pub struct ExplicitBacktrace {
         #[backtrace]
         backtrace: Backtrace,
+    }
+
+    #[derive(Error, Debug)]
+    #[error("...")]
+    pub struct NotBacktrace {
+        backtrace: crate::structs::not_backtrace::r#Backtrace,
     }
 
     #[derive(Error, Debug)]


### PR DESCRIPTION
Without `r#Backtrace`:

```console
error[E0308]: mismatched types
   --> tests/test_backtrace.rs:42:14
    |
42  |     #[derive(Error, Debug)]
    |              ^^^^^
    |              |
    |              expected `std::backtrace::Backtrace`, found `not_backtrace::Backtrace`
    |              arguments to this method are incorrect
    |
    = note: `not_backtrace::Backtrace` and `std::backtrace::Backtrace` have similar names, but are actually distinct types
note: `not_backtrace::Backtrace` is defined in the current crate
   --> tests/test_backtrace.rs:26:9
    |
26  |         pub struct Backtrace;
    |         ^^^^^^^^^^^^^^^^^^^^
note: `std::backtrace::Backtrace` is defined in crate `std`
   --> $RUSTUP_HOME/toolchains/nightly-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/backtrace.rs:108:1
    |
108 | pub struct Backtrace {
    | ^^^^^^^^^^^^^^^^^^^^
note: method defined here
   --> $RUSTUP_HOME/toolchains/nightly-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/error.rs:607:12
    |
607 |     pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'a T) -> &mut Self {
    |            ^^^^^^^^^^^
    = note: this error originates in the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)
```