### PR TITLE
Add ui test of colliding From impls

### DIFF
--- a/tests/ui/same-from-type.rs
+++ b/tests/ui/same-from-type.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("failed to open")]
+    OpenFile(#[from] std::io::Error),
+    #[error("failed to close")]
+    CloseFIle(#[from] std::io::Error),
+}
+
+fn main() {}

--- a/tests/ui/same-from-type.stderr
+++ b/tests/ui/same-from-type.stderr
@@ -1,0 +1,5 @@
+error: cannot derive From because another variant has the same source type
+ --> tests/ui/same-from-type.rs:8:15
+  |
+8 |     CloseFIle(#[from] std::io::Error),
+  |               ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
There should have been a test for this in #30.

Without the dedicated diagnostic from impl/src/valid.rs, the error is:

```console
error[E0119]: conflicting implementations of trait `From<std::io::Error>` for type `Error`
 --> tests/ui/same-from-type.rs:3:10
  |
3 | #[derive(Error, Debug)]
  |          ^^^^^
  |          |
  |          first implementation here
  |          conflicting implementation for `Error`
  |
  = note: this error originates in the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)
```

It may make sense to look into whether we can remove the dedicated diagnostic, and rearrange some spans so that "first implementation here" and "conflicting implementation for 'Error'" actually point out the two `#[from]` attributes at play.