### PR TITLE
Store span of #[source] and #[from] attribute

### DIFF
--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -75,9 +75,9 @@ impl Field<'_> {
 
     pub(crate) fn source_span(&self) -> Span {
         if let Some(source_attr) = &self.attrs.source {
-            source_attr.path().get_ident().unwrap().span()
+            source_attr.span
         } else if let Some(from_attr) = &self.attrs.from {
-            from_attr.path().get_ident().unwrap().span()
+            from_attr.span
         } else {
             self.member.span()
         }


### PR DESCRIPTION
These will be useful to use in `quote_spanned`, such as for what's described in #361.