### PR TITLE
Allow error(transparent) inside an enum that has error("...")

### DIFF
--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -91,14 +91,13 @@ impl<'a> Enum<'a> {
             .iter()
             .map(|node| {
                 let mut variant = Variant::from_syn(node, &scope)?;
-                if let display @ None = &mut variant.attrs.display {
-                    display.clone_from(&attrs.display);
+                if variant.attrs.display.is_none() && variant.attrs.transparent.is_none() {
+                    variant.attrs.display.clone_from(&attrs.display);
+                    variant.attrs.transparent = attrs.transparent;
                 }
                 if let Some(display) = &mut variant.attrs.display {
                     let container = ContainerKind::from_variant(node);
                     display.expand_shorthand(&variant.fields, container)?;
-                } else if variant.attrs.transparent.is_none() {
-                    variant.attrs.transparent = attrs.transparent;
                 }
                 Ok(variant)
             })

--- a/tests/test_transparent.rs
+++ b/tests/test_transparent.rs
@@ -46,6 +46,24 @@ fn test_transparent_enum() {
 }
 
 #[test]
+fn test_transparent_enum_with_default_message() {
+    #[derive(Error, Debug)]
+    #[error("this failed: {0}_{1}")]
+    enum Error {
+        This(i32, i32),
+        #[error(transparent)]
+        Other(anyhow::Error),
+    }
+
+    let error = Error::This(-1, -1);
+    assert_eq!("this failed: -1_-1", error.to_string());
+
+    let error = Error::Other(anyhow!("inner").context("outer"));
+    assert_eq!("outer", error.to_string());
+    assert_eq!("inner", error.source().unwrap().to_string());
+}
+
+#[test]
 fn test_anyhow() {
     #[derive(Error, Debug)]
     #[error(transparent)]


### PR DESCRIPTION
I cannot tell why this was disallowed originally. Probably just buggy implementation logic.