### PR TITLE
Implement #[error(fmt = ...)]

### DIFF
--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -91,9 +91,13 @@ impl<'a> Enum<'a> {
             .iter()
             .map(|node| {
                 let mut variant = Variant::from_syn(node, &scope)?;
-                if variant.attrs.display.is_none() && variant.attrs.transparent.is_none() {
+                if variant.attrs.display.is_none()
+                    && variant.attrs.transparent.is_none()
+                    && variant.attrs.fmt.is_none()
+                {
                     variant.attrs.display.clone_from(&attrs.display);
                     variant.attrs.transparent = attrs.transparent;
+                    variant.attrs.fmt.clone_from(&attrs.fmt);
                 }
                 if let Some(display) = &mut variant.attrs.display {
                     let container = ContainerKind::from_variant(node);

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -38,10 +38,11 @@ impl Enum<'_> {
     pub(crate) fn has_display(&self) -> bool {
         self.attrs.display.is_some()
             || self.attrs.transparent.is_some()
+            || self.attrs.fmt.is_some()
             || self
                 .variants
                 .iter()
-                .any(|variant| variant.attrs.display.is_some())
+                .any(|variant| variant.attrs.display.is_some() || variant.attrs.fmt.is_some())
             || self
                 .variants
                 .iter()

--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -1,6 +1,7 @@
 #![allow(
     clippy::needless_lifetimes,
     clippy::needless_raw_string_hashes,
+    clippy::trivially_copy_pass_by_ref,
     clippy::uninlined_format_args
 )]
 

--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -370,3 +370,69 @@ fn test_raw_str() {
     assert(r#"raw brace right }"#, Error::BraceRight);
     assert(r#"raw brace right 2 \x7D"#, Error::BraceRight2);
 }
+
+mod util {
+    use core::fmt::{self, Octal};
+
+    pub fn octal<T: Octal>(value: &T, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "0o{:o}", value)
+    }
+}
+
+#[test]
+fn test_fmt_path() {
+    fn unit(formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("unit=")
+    }
+
+    fn pair(k: &i32, v: &i32, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "pair={k}:{v}")
+    }
+
+    #[derive(Error, Debug)]
+    pub enum Error {
+        #[error(fmt = unit)]
+        Unit,
+        #[error(fmt = pair)]
+        Tuple(i32, i32),
+        #[error(fmt = pair)]
+        Entry { k: i32, v: i32 },
+        #[error(fmt = crate::util::octal)]
+        I16(i16),
+        #[error(fmt = crate::util::octal::<i32>)]
+        I32 { n: i32 },
+        #[error(fmt = core::fmt::Octal::fmt)]
+        I64(i64),
+        #[error("...{0}")]
+        Other(bool),
+    }
+
+    assert("unit=", Error::Unit);
+    assert("pair=10:0", Error::Tuple(10, 0));
+    assert("pair=10:0", Error::Entry { k: 10, v: 0 });
+    assert("0o777", Error::I16(0o777));
+    assert("0o777", Error::I32 { n: 0o777 });
+    assert("777", Error::I64(0o777));
+    assert("...false", Error::Other(false));
+}
+
+#[test]
+fn test_fmt_path_inherited() {
+    #[derive(Error, Debug)]
+    #[error(fmt = crate::util::octal)]
+    pub enum Error {
+        I16(i16),
+        I32 {
+            n: i32,
+        },
+        #[error(fmt = core::fmt::Octal::fmt)]
+        I64(i64),
+        #[error("...{0}")]
+        Other(bool),
+    }
+
+    assert("0o777", Error::I16(0o777));
+    assert("0o777", Error::I32 { n: 0o777 });
+    assert("777", Error::I64(0o777));
+    assert("...false", Error::Other(false));
+}

--- a/tests/ui/concat-display.stderr
+++ b/tests/ui/concat-display.stderr
@@ -1,4 +1,4 @@
-error: expected string literal or `transparent`
+error: expected one of: string literal, `transparent`, `fmt`
   --> tests/ui/concat-display.rs:8:17
    |
 8  |         #[error(concat!("invalid ", $what))]

--- a/tests/ui/duplicate-fmt.rs
+++ b/tests/ui/duplicate-fmt.rs
@@ -5,4 +5,19 @@ use thiserror::Error;
 #[error("...")]
 pub struct Error;
 
+#[derive(Error, Debug)]
+#[error(fmt = core::fmt::Octal::fmt)]
+#[error(fmt = core::fmt::LowerHex::fmt)]
+pub enum FmtFmt {}
+
+#[derive(Error, Debug)]
+#[error(fmt = core::fmt::Octal::fmt)]
+#[error(transparent)]
+pub enum FmtTransparent {}
+
+#[derive(Error, Debug)]
+#[error(fmt = core::fmt::Octal::fmt)]
+#[error("...")]
+pub enum FmtDisplay {}
+
 fn main() {}

--- a/tests/ui/duplicate-fmt.stderr
+++ b/tests/ui/duplicate-fmt.stderr
@@ -3,3 +3,21 @@ error: only one #[error(...)] attribute is allowed
   |
 5 | #[error("...")]
   | ^^^^^^^^^^^^^^^
+
+error: duplicate #[error(fmt = ...)] attribute
+  --> tests/ui/duplicate-fmt.rs:10:1
+   |
+10 | #[error(fmt = core::fmt::LowerHex::fmt)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot have both #[error(transparent)] and #[error(fmt = ...)]
+  --> tests/ui/duplicate-fmt.rs:14:1
+   |
+14 | #[error(fmt = core::fmt::Octal::fmt)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot have both #[error(fmt = ...)] and a format arguments attribute
+  --> tests/ui/duplicate-fmt.rs:20:1
+   |
+20 | #[error("...")]
+   | ^^^^^^^^^^^^^^^

--- a/tests/ui/struct-with-fmt.rs
+++ b/tests/ui/struct-with-fmt.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(fmt = core::fmt::Octal::fmt)]
+pub struct Error(i32);
+
+fn main() {}

--- a/tests/ui/struct-with-fmt.stderr
+++ b/tests/ui/struct-with-fmt.stderr
@@ -1,0 +1,5 @@
+error: #[error(fmt = ...)] is only supported in enums; for a struct, handwrite your own Display impl
+ --> tests/ui/struct-with-fmt.rs:4:1
+  |
+4 | #[error(fmt = core::fmt::Octal::fmt)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Before:

```rust
#[derive(Error, Debug)]
pub enum Error {
    #[error("{code}{}", match .message {
        Some(msg) => format!(" - {}", &msg),
        None => "".to_owned(),
    })]
    Demo { code: u16, message: Option<String> },
}
```

After:

```rust
#[derive(Error, Debug)]
pub enum Error {
    #[error(fmt = demo_fmt)]
    Demo { code: u16, message: Option<String> },
}

fn demo_fmt(code: &u16, message: &Option<String>, formatter: &mut fmt::Formatter) -> fmt::Result {
    write!(formatter, "{code}")?;
    if let Some(msg) = message {
        write!(formatter, " - {msg}")?;
    }
    Ok(())
}
```

This avoids forcing allocations (or the even worse workarounds in #201) and keeps elaborate formatting logic out of the data structure.

The parameter order is designed to be usable with generic methods.

```rust
#[derive(Error, Debug)]
#[error(fmt = core::fmt::Octal::fmt)]
pub enum Error {
    I32(i32),
    I64(i64),
}
```