### PR TITLE
Access all std types through absolute path

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -37,7 +37,7 @@ fn fallback(input: &DeriveInput, error: syn::Error) -> TokenStream {
 
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics std::error::Error for #ty #ty_generics #where_clause
+        impl #impl_generics ::std::error::Error for #ty #ty_generics #where_clause
         where
             // Work around trivial bounds being unstable.
             // https://github.com/rust-lang/rust/issues/48214
@@ -62,17 +62,17 @@ fn impl_struct(input: Struct) -> TokenStream {
     let source_body = if let Some(transparent_attr) = &input.attrs.transparent {
         let only_field = &input.fields[0];
         if only_field.contains_generic {
-            error_inferred_bounds.insert(only_field.ty, quote!(std::error::Error));
+            error_inferred_bounds.insert(only_field.ty, quote!(::std::error::Error));
         }
         let member = &only_field.member;
         Some(quote_spanned! {transparent_attr.span=>
-            std::error::Error::source(self.#member.as_dyn_error())
+            ::std::error::Error::source(self.#member.as_dyn_error())
         })
     } else if let Some(source_field) = input.source_field() {
         let source = &source_field.member;
         if source_field.contains_generic {
             let ty = unoptional_type(source_field.ty);
-            error_inferred_bounds.insert(ty, quote!(std::error::Error + 'static));
+            error_inferred_bounds.insert(ty, quote!(::std::error::Error + 'static));
         }
         let asref = if type_is_option(source_field.ty) {
             Some(quote_spanned!(source.span()=> .as_ref()?))
@@ -90,7 +90,7 @@ fn impl_struct(input: Struct) -> TokenStream {
     };
     let source_method = source_body.map(|body| {
         quote! {
-            fn source(&self) -> ::core::option::Option<&(dyn std::error::Error + 'static)> {
+            fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
                 use ::thiserror::__private::AsDynError as _;
                 #body
             }
@@ -118,12 +118,12 @@ fn impl_struct(input: Struct) -> TokenStream {
             } else if type_is_option(backtrace_field.ty) {
                 Some(quote! {
                     if let ::core::option::Option::Some(backtrace) = &self.#backtrace {
-                        #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
+                        #request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
                     }
                 })
             } else {
                 Some(quote! {
-                    #request.provide_ref::<std::backtrace::Backtrace>(&self.#backtrace);
+                    #request.provide_ref::<::std::backtrace::Backtrace>(&self.#backtrace);
                 })
             };
             quote! {
@@ -134,16 +134,16 @@ fn impl_struct(input: Struct) -> TokenStream {
         } else if type_is_option(backtrace_field.ty) {
             quote! {
                 if let ::core::option::Option::Some(backtrace) = &self.#backtrace {
-                    #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
+                    #request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
                 }
             }
         } else {
             quote! {
-                #request.provide_ref::<std::backtrace::Backtrace>(&self.#backtrace);
+                #request.provide_ref::<::std::backtrace::Backtrace>(&self.#backtrace);
             }
         };
         quote! {
-            fn provide<'_request>(&'_request self, #request: &mut std::error::Request<'_request>) {
+            fn provide<'_request>(&'_request self, #request: &mut ::std::error::Request<'_request>) {
                 #body
             }
         }
@@ -218,7 +218,7 @@ fn impl_struct(input: Struct) -> TokenStream {
     quote! {
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics std::error::Error for #ty #ty_generics #error_where_clause {
+        impl #impl_generics ::std::error::Error for #ty #ty_generics #error_where_clause {
             #source_method
             #provide_method
         }
@@ -238,11 +238,11 @@ fn impl_enum(input: Enum) -> TokenStream {
             if let Some(transparent_attr) = &variant.attrs.transparent {
                 let only_field = &variant.fields[0];
                 if only_field.contains_generic {
-                    error_inferred_bounds.insert(only_field.ty, quote!(std::error::Error));
+                    error_inferred_bounds.insert(only_field.ty, quote!(::std::error::Error));
                 }
                 let member = &only_field.member;
                 let source = quote_spanned! {transparent_attr.span=>
-                    std::error::Error::source(transparent.as_dyn_error())
+                    ::std::error::Error::source(transparent.as_dyn_error())
                 };
                 quote! {
                     #ty::#ident {#member: transparent} => #source,
@@ -251,7 +251,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                 let source = &source_field.member;
                 if source_field.contains_generic {
                     let ty = unoptional_type(source_field.ty);
-                    error_inferred_bounds.insert(ty, quote!(std::error::Error + 'static));
+                    error_inferred_bounds.insert(ty, quote!(::std::error::Error + 'static));
                 }
                 let asref = if type_is_option(source_field.ty) {
                     Some(quote_spanned!(source.span()=> .as_ref()?))
@@ -272,7 +272,7 @@ fn impl_enum(input: Enum) -> TokenStream {
             }
         });
         Some(quote! {
-            fn source(&self) -> ::core::option::Option<&(dyn std::error::Error + 'static)> {
+            fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
                 use ::thiserror::__private::AsDynError as _;
                 #[allow(deprecated)]
                 match self {
@@ -309,12 +309,12 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let self_provide = if type_is_option(backtrace_field.ty) {
                         quote! {
                             if let ::core::option::Option::Some(backtrace) = backtrace {
-                                #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
+                                #request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
                             }
                         }
                     } else {
                         quote! {
-                            #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
+                            #request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
                         }
                     };
                     quote! {
@@ -357,12 +357,12 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let body = if type_is_option(backtrace_field.ty) {
                         quote! {
                             if let ::core::option::Option::Some(backtrace) = backtrace {
-                                #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
+                                #request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
                             }
                         }
                     } else {
                         quote! {
-                            #request.provide_ref::<std::backtrace::Backtrace>(backtrace);
+                            #request.provide_ref::<::std::backtrace::Backtrace>(backtrace);
                         }
                     };
                     quote! {
@@ -377,7 +377,7 @@ fn impl_enum(input: Enum) -> TokenStream {
             }
         });
         Some(quote! {
-            fn provide<'_request>(&'_request self, #request: &mut std::error::Request<'_request>) {
+            fn provide<'_request>(&'_request self, #request: &mut ::std::error::Request<'_request>) {
                 #[allow(deprecated)]
                 match self {
                     #(#arms)*
@@ -483,7 +483,7 @@ fn impl_enum(input: Enum) -> TokenStream {
     quote! {
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics std::error::Error for #ty #ty_generics #error_where_clause {
+        impl #impl_generics ::std::error::Error for #ty #ty_generics #error_where_clause {
             #source_method
             #provide_method
         }
@@ -532,11 +532,11 @@ fn from_initializer(
         let backtrace_member = &backtrace_field.member;
         if type_is_option(backtrace_field.ty) {
             quote! {
-                #backtrace_member: ::core::option::Option::Some(std::backtrace::Backtrace::capture()),
+                #backtrace_member: ::core::option::Option::Some(::std::backtrace::Backtrace::capture()),
             }
         } else {
             quote! {
-                #backtrace_member: ::core::convert::From::from(std::backtrace::Backtrace::capture()),
+                #backtrace_member: ::core::convert::From::from(::std::backtrace::Backtrace::capture()),
             }
         }
     });


### PR DESCRIPTION
The previous expansion was designed to facilitate "fake std" facade modules like in https://github.com/dtolnay/thiserror/pull/64#issuecomment-612570677. That is no longer supported in the new implementation, and `Error` will always refer to the standard library Error trait.