### PR TITLE
Access Error trait exclusively through ::thiserror

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -37,7 +37,7 @@ fn fallback(input: &DeriveInput, error: syn::Error) -> TokenStream {
 
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics ::std::error::Error for #ty #ty_generics #where_clause
+        impl #impl_generics ::thiserror::__private::Error for #ty #ty_generics #where_clause
         where
             // Work around trivial bounds being unstable.
             // https://github.com/rust-lang/rust/issues/48214
@@ -62,17 +62,17 @@ fn impl_struct(input: Struct) -> TokenStream {
     let source_body = if let Some(transparent_attr) = &input.attrs.transparent {
         let only_field = &input.fields[0];
         if only_field.contains_generic {
-            error_inferred_bounds.insert(only_field.ty, quote!(::std::error::Error));
+            error_inferred_bounds.insert(only_field.ty, quote!(::thiserror::__private::Error));
         }
         let member = &only_field.member;
         Some(quote_spanned! {transparent_attr.span=>
-            ::std::error::Error::source(self.#member.as_dyn_error())
+            ::thiserror::__private::Error::source(self.#member.as_dyn_error())
         })
     } else if let Some(source_field) = input.source_field() {
         let source = &source_field.member;
         if source_field.contains_generic {
             let ty = unoptional_type(source_field.ty);
-            error_inferred_bounds.insert(ty, quote!(::std::error::Error + 'static));
+            error_inferred_bounds.insert(ty, quote!(::thiserror::__private::Error + 'static));
         }
         let asref = if type_is_option(source_field.ty) {
             Some(quote_spanned!(source.span()=> .as_ref()?))
@@ -90,7 +90,7 @@ fn impl_struct(input: Struct) -> TokenStream {
     };
     let source_method = source_body.map(|body| {
         quote! {
-            fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
+            fn source(&self) -> ::core::option::Option<&(dyn ::thiserror::__private::Error + 'static)> {
                 use ::thiserror::__private::AsDynError as _;
                 #body
             }
@@ -218,7 +218,7 @@ fn impl_struct(input: Struct) -> TokenStream {
     quote! {
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics ::std::error::Error for #ty #ty_generics #error_where_clause {
+        impl #impl_generics ::thiserror::__private::Error for #ty #ty_generics #error_where_clause {
             #source_method
             #provide_method
         }
@@ -238,11 +238,11 @@ fn impl_enum(input: Enum) -> TokenStream {
             if let Some(transparent_attr) = &variant.attrs.transparent {
                 let only_field = &variant.fields[0];
                 if only_field.contains_generic {
-                    error_inferred_bounds.insert(only_field.ty, quote!(::std::error::Error));
+                    error_inferred_bounds.insert(only_field.ty, quote!(::thiserror::__private::Error));
                 }
                 let member = &only_field.member;
                 let source = quote_spanned! {transparent_attr.span=>
-                    ::std::error::Error::source(transparent.as_dyn_error())
+                    ::thiserror::__private::Error::source(transparent.as_dyn_error())
                 };
                 quote! {
                     #ty::#ident {#member: transparent} => #source,
@@ -251,7 +251,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                 let source = &source_field.member;
                 if source_field.contains_generic {
                     let ty = unoptional_type(source_field.ty);
-                    error_inferred_bounds.insert(ty, quote!(::std::error::Error + 'static));
+                    error_inferred_bounds.insert(ty, quote!(::thiserror::__private::Error + 'static));
                 }
                 let asref = if type_is_option(source_field.ty) {
                     Some(quote_spanned!(source.span()=> .as_ref()?))
@@ -272,7 +272,7 @@ fn impl_enum(input: Enum) -> TokenStream {
             }
         });
         Some(quote! {
-            fn source(&self) -> ::core::option::Option<&(dyn ::std::error::Error + 'static)> {
+            fn source(&self) -> ::core::option::Option<&(dyn ::thiserror::__private::Error + 'static)> {
                 use ::thiserror::__private::AsDynError as _;
                 #[allow(deprecated)]
                 match self {
@@ -483,7 +483,7 @@ fn impl_enum(input: Enum) -> TokenStream {
     quote! {
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics ::std::error::Error for #ty #ty_generics #error_where_clause {
+        impl #impl_generics ::thiserror::__private::Error for #ty #ty_generics #error_where_clause {
             #source_method
             #provide_method
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,4 +287,6 @@ pub mod __private {
     #[cfg(error_generic_member_access)]
     #[doc(hidden)]
     pub use crate::provide::ThiserrorProvide;
+    #[doc(hidden)]
+    pub use std::error::Error;
 }


### PR DESCRIPTION
This gives control of the meaning of `Error` in derive-generated code to the `thiserror` crate's build script and its enabled feature combinations.