### PR TITLE
Emit rebinding only for interpolations that refer to a field

### DIFF
--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -60,11 +60,10 @@ impl Display<'_> {
                             return Err(Error::new_spanned(first_unnamed, msg));
                         }
                     }
-                    let member = match int.parse::<u32>() {
+                    match int.parse::<u32>() {
                         Ok(index) => MemberUnraw::Unnamed(Index { index, span }),
                         Err(_) => return Ok(()),
-                    };
-                    member
+                    }
                 }
                 'a'..='z' | 'A'..='Z' | '_' => {
                     if read.starts_with("r#") {

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -64,10 +64,6 @@ impl Display<'_> {
                         Ok(index) => MemberUnraw::Unnamed(Index { index, span }),
                         Err(_) => return Ok(()),
                     };
-                    if !member_index.contains_key(&member) {
-                        out += int;
-                        continue;
-                    }
                     member
                 }
                 'a'..='z' | 'A'..='Z' | '_' => {
@@ -109,16 +105,17 @@ impl Display<'_> {
                 Some('E') => Trait::UpperExp,
                 Some(_) => Trait::Display,
                 None => {
-                    if member_index.contains_key(&member) {
-                        has_bonus_display = true;
-                        binding_value.extend(quote_spanned!(span=> .as_display()));
-                    }
+                    has_bonus_display = true;
+                    binding_value.extend(quote_spanned!(span=> .as_display()));
                     Trait::Display
                 }
             };
             infinite_recursive |= member == *"self" && bound == Trait::Display;
             if let Some(&field) = member_index.get(&member) {
                 implied_bounds.insert((field, bound));
+            } else {
+                out += &member.to_string();
+                continue;
             }
             let mut formatvar = IdentUnraw::new(match &member {
                 MemberUnraw::Unnamed(index) => format_ident!("__field{}", index),

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -116,6 +116,7 @@ impl Display<'_> {
                     Trait::Display
                 }
             };
+            infinite_recursive |= member == *"self" && bound == Trait::Display;
             if let Some(&field) = member_index.get(&member) {
                 implied_bounds.insert((field, bound));
             }
@@ -128,7 +129,6 @@ impl Display<'_> {
             }
             out += &formatvar.to_string();
             let local = formatvar.to_local();
-            infinite_recursive |= member == *"self" && bound == Trait::Display;
             if macro_named_args.insert(member) {
                 bindings.push((local, binding_value));
             } else {

--- a/impl/src/fmt.rs
+++ b/impl/src/fmt.rs
@@ -90,15 +90,6 @@ impl Display<'_> {
                 }
                 _ => continue,
             };
-            let mut formatvar = IdentUnraw::new(match &member {
-                MemberUnraw::Unnamed(index) => format_ident!("__field{}", index),
-                MemberUnraw::Named(ident) => format_ident!("__field_{}", ident.to_string()),
-            });
-            while user_named_args.contains(&formatvar) {
-                formatvar = IdentUnraw::new(format_ident!("_{}", formatvar.to_string()));
-            }
-            out += &formatvar.to_string();
-            let local = formatvar.to_local();
             let mut binding_value = ToTokens::into_token_stream(match &member {
                 MemberUnraw::Unnamed(index) => format_ident!("_{}", index),
                 MemberUnraw::Named(ident) => ident.to_local(),
@@ -128,6 +119,15 @@ impl Display<'_> {
             if let Some(&field) = member_index.get(&member) {
                 implied_bounds.insert((field, bound));
             }
+            let mut formatvar = IdentUnraw::new(match &member {
+                MemberUnraw::Unnamed(index) => format_ident!("__field{}", index),
+                MemberUnraw::Named(ident) => format_ident!("__field_{}", ident.to_string()),
+            });
+            while user_named_args.contains(&formatvar) {
+                formatvar = IdentUnraw::new(format_ident!("_{}", formatvar.to_string()));
+            }
+            out += &formatvar.to_string();
+            let local = formatvar.to_local();
             infinite_recursive |= member == *"self" && bound == Trait::Display;
             if macro_named_args.insert(member) {
                 bindings.push((local, binding_value));

--- a/impl/src/unraw.rs
+++ b/impl/src/unraw.rs
@@ -89,6 +89,15 @@ impl MemberUnraw {
     }
 }
 
+impl Display for MemberUnraw {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MemberUnraw::Named(this) => Display::fmt(this, formatter),
+            MemberUnraw::Unnamed(this) => Display::fmt(&this.index, formatter),
+        }
+    }
+}
+
 impl Eq for MemberUnraw {}
 
 impl PartialEq for MemberUnraw {


### PR DESCRIPTION
For something like:

```rust
const CODE: usize = 9;

#[derive(Error, Debug)]
#[error("{id:?} (code {CODE:?})")]
pub struct Error {
    pub id: &'static str,
}
```

Before:

```rust
let Self { id } = self;
match (id, CODE) {
    (__field_id, __field_CODE) => {
        __formatter.write_fmt(format_args!("{__field_id:?} (code {__field_CODE:?})"))
    }
}
```

After:

```rust
let Self { id } = self;
match (id,) {
    (__field_id,) => {
        __formatter.write_fmt(format_args!("{__field_id:?} (code {CODE:?})"))
    }
}
```