### PR TITLE
Support Display and Debug of same path in error message

### DIFF
--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -29,6 +29,14 @@ pub struct UnsizedError {
     pub tail: str,
 }
 
+#[derive(Error, Debug)]
+pub enum BothError {
+    #[error("display:{0} debug:{0:?}")]
+    DisplayDebug(PathBuf),
+    #[error("debug:{0:?} display:{0}")]
+    DebugDisplay(PathBuf),
+}
+
 fn assert<T: Display>(expected: &str, value: T) {
     assert_eq!(expected, value.to_string());
 }


### PR DESCRIPTION
Previously, for an error containing a Path or PathBuf, `#[error("display:{0} debug:{0:?}")]` would work but `#[error("debug:{0:?} display:{0}")]` would not compile.

```console
error[E0277]: `PathBuf` doesn't implement `std::fmt::Display`
  --> tests/test_path.rs:36:13
   |
32 | #[derive(Error, Debug)]
   |          ----- in this derive macro expansion
...
36 |     #[error("debug:{0:?} display:{0}")]
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ `PathBuf` cannot be formatted with the default formatter; call `.display()` on it
   |
   = help: the trait `std::fmt::Display` is not implemented for `PathBuf`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
   = help: the trait `std::fmt::Display` is implemented for `Var<'_, T>`
   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the derive macro `Error` (in Nightly builds, run with -Z macro-backtrace for more info)
```