### PR TITLE
suppress needless_lifetimes lints from clippy 0.1.83

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -197,7 +197,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         let source_var = Ident::new("source", span);
         let body = from_initializer(from_field, backtrace_field, &source_var);
         quote_spanned! {span=>
-            #[allow(unused_qualifications)]
+            #[allow(unused_qualifications, clippy::needless_lifetimes)]
             #[automatically_derived]
             impl #impl_generics ::core::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]
@@ -462,7 +462,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         let source_var = Ident::new("source", span);
         let body = from_initializer(from_field, backtrace_field, &source_var);
         Some(quote_spanned! {span=>
-            #[allow(unused_qualifications)]
+            #[allow(unused_qualifications, clippy::needless_lifetimes)]
             #[automatically_derived]
             impl #impl_generics ::core::convert::From<#from> for #ty #ty_generics #where_clause {
                 #[allow(deprecated)]

--- a/tests/test_lints.rs
+++ b/tests/test_lints.rs
@@ -18,3 +18,18 @@ fn test_unused_qualifications() {
 
     let _: MyError;
 }
+
+#[test]
+fn test_needless_lifetimes() {
+    #![allow(dead_code)]
+    #![deny(clippy::needless_lifetimes)]
+
+    #[derive(Debug, Error)]
+    #[error("...")]
+    pub enum MyError<'a> {
+        A(#[from] std::io::Error),
+        B(&'a ()),
+    }
+
+    let _: MyError;
+}


### PR DESCRIPTION
I think I did this correctly.

In Clippy 0.1.83, without the changes in `expand.rs`, the new test in `test_lints.rs` fails with the following output:

```
error: the following explicit lifetimes could be elided: 'a
  --> tests/test_lints.rs:29:22
   |
29 |     pub enum MyError<'a> {
   |                      ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
note: the lint level is defined here
  --> tests/test_lints.rs:25:13
   |
25 |     #![deny(clippy::needless_lifetimes)]
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
help: elide the lifetimes
   |
29 -     pub enum MyError<'a> {
29 +     pub enum MyError'_> {
   |

error: could not compile `thiserror` (test "test_lints") due to 1 previous error
```

Clippy doesn't like the generated `impl From` and gets confused about what it's fixing (rust-lang/rust-clippy#12789?) and the result is a confusing message suggesting code that is broken in multiple ways. The `Display` and `Error` impls don't seem to be affected, so this probably only affects users that use borrowed errors and `#[from]`.

I encountered this in a project I can't share, but it's the same case as https://github.com/ruffle-rs/ruffle/pull/18761 https://github.com/ruffle-rs/ruffle/blob/bd89e5b216769168d08548f01e2b6871280ab829/core/src/avm1/error.rs