### PR TITLE
Avoid associating #[from] with lint allow

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -169,15 +169,18 @@ fn impl_struct(input: Struct) -> TokenStream {
         let from = unoptional_type(from_field.ty);
         let source_var = Ident::new("source", span);
         let body = from_initializer(from_field, backtrace_field, &source_var);
-        quote_spanned! {span=>
-            #[allow(deprecated, unused_qualifications, clippy::needless_lifetimes)]
+        let impl_impl = quote_spanned! {span=>
             #[automatically_derived]
             impl #impl_generics ::core::convert::From<#from> for #ty #ty_generics #where_clause {
                 fn from(#source_var: #from) -> Self {
                     #ty #body
                 }
             }
-        }
+        };
+        Some(quote! {
+            #[allow(deprecated, unused_qualifications, clippy::needless_lifetimes)]
+            #impl_impl
+        })
     });
 
     if input.generics.type_params().next().is_some() {
@@ -433,14 +436,17 @@ fn impl_enum(input: Enum) -> TokenStream {
         let from = unoptional_type(from_field.ty);
         let source_var = Ident::new("source", span);
         let body = from_initializer(from_field, backtrace_field, &source_var);
-        Some(quote_spanned! {span=>
-            #[allow(deprecated, unused_qualifications, clippy::needless_lifetimes)]
+        let impl_impl = quote_spanned! {span=>
             #[automatically_derived]
             impl #impl_generics ::core::convert::From<#from> for #ty #ty_generics #where_clause {
                 fn from(#source_var: #from) -> Self {
                     #ty::#variant #body
                 }
             }
+        };
+        Some(quote! {
+            #[allow(deprecated, unused_qualifications, clippy::needless_lifetimes)]
+            #impl_impl
         })
     });
 

--- a/tests/test_lints.rs
+++ b/tests/test_lints.rs
@@ -5,6 +5,17 @@ use thiserror::Error;
 pub use std::error::Error;
 
 #[test]
+fn test_allow_attributes() {
+    #![deny(clippy::allow_attributes)]
+
+    #[derive(Error, Debug)]
+    #[error("...")]
+    pub struct MyError(#[from] anyhow::Error);
+
+    let _: MyError;
+}
+
+#[test]
 fn test_unused_qualifications() {
     #![deny(unused_qualifications)]
 


### PR DESCRIPTION
Fixes:

    error: #[allow] attribute found
      --> src/lib.rs:13:26
       |
    13 | pub struct DownloadError(#[from] std::io::Error);
       |                          ^^^^^^^ help: replace it with: `expect`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#allow_attributes
    note: the lint level is defined here
      --> src/lib.rs:1:9
       |
    1  | #![deny(clippy::allow_attributes)]
       |         ^^^^^^^^^^^^^^^^^^^^^^^^

I could only repro with `RUSTC_BOOTSTRAP=1` on 1.83.0. Couldn't repro
with beta or nightly. So maybe this fix isn't worth it.

Issue is discussed at
https://github.com/rust-lang/rust-clippy/issues/13349