### PR TITLE
Fix spans on macro-generated bindings and format variables

### DIFF
--- a/impl/src/unraw.rs
+++ b/impl/src/unraw.rs
@@ -28,6 +28,10 @@ impl IdentUnraw {
         }
         unraw
     }
+
+    pub fn set_span(&mut self, span: Span) {
+        self.0.set_span(span);
+    }
 }
 
 impl Display for IdentUnraw {

--- a/tests/test_display.rs
+++ b/tests/test_display.rs
@@ -266,7 +266,7 @@ fn test_pointer() {
 }
 
 #[test]
-fn test_macro_rules() {
+fn test_macro_rules_variant_from_call_site() {
     // Regression test for https://github.com/dtolnay/thiserror/issues/86
 
     macro_rules! decl_error {
@@ -289,6 +289,30 @@ fn test_macro_rules() {
 
     assert("0", Error0::Repro(0));
     assert("0", Error1::Repro(0));
+}
+
+#[test]
+fn test_macro_rules_message_from_call_site() {
+    // Regression test for https://github.com/dtolnay/thiserror/issues/398
+
+    macro_rules! decl_error {
+        ($($errors:tt)*) => {
+            #[derive(Error, Debug)]
+            pub enum Error {
+                $($errors)*
+            }
+        };
+    }
+
+    decl_error! {
+        #[error("{0}")]
+        Unnamed(u8),
+        #[error("{x}")]
+        Named { x: u8 },
+    }
+
+    assert("0", Error::Unnamed(0));
+    assert("0", Error::Named { x: 0 });
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/dtolnay/thiserror/issues/398.