### PR TITLE
#[implicit] fields for automatic data collection when building errors using From<source>

### DIFF
--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -12,6 +12,7 @@ pub struct Attrs<'a> {
     pub display: Option<Display<'a>>,
     pub source: Option<Source<'a>>,
     pub backtrace: Option<&'a Attribute>,
+    pub implicit: Option<&'a Attribute>,
     pub from: Option<From<'a>>,
     pub transparent: Option<Transparent<'a>>,
     pub fmt: Option<Fmt<'a>>,
@@ -71,6 +72,7 @@ pub fn get(input: &[Attribute]) -> Result<Attrs> {
         display: None,
         source: None,
         backtrace: None,
+        implicit: None,
         from: None,
         transparent: None,
         fmt: None,
@@ -97,6 +99,12 @@ pub fn get(input: &[Attribute]) -> Result<Attrs> {
                 return Err(Error::new_spanned(attr, "duplicate #[backtrace] attribute"));
             }
             attrs.backtrace = Some(attr);
+        } else if attr.path().is_ident("implicit") {
+            attr.meta.require_path_only()?;
+            if attrs.implicit.is_some() {
+                return Err(Error::new_spanned(attr, "duplicate #[implicit] attribute"));
+            }
+            attrs.implicit = Some(attr);
         } else if attr.path().is_ident("from") {
             match attr.meta {
                 Meta::Path(_) => {}

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -32,7 +32,7 @@ mod valid;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-#[proc_macro_derive(Error, attributes(backtrace, error, from, source))]
+#[proc_macro_derive(Error, attributes(backtrace, error, from, source, implicit))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input).into()

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -20,6 +20,10 @@ impl Struct<'_> {
         let backtrace_field = self.backtrace_field()?;
         distinct_backtrace_field(backtrace_field, self.from_field())
     }
+
+    pub(crate) fn implicit_fields(&self) -> Vec<&Field> {
+        implicit_fields(&self.fields)
+    }
 }
 
 impl Enum<'_> {
@@ -67,11 +71,19 @@ impl Variant<'_> {
         let backtrace_field = self.backtrace_field()?;
         distinct_backtrace_field(backtrace_field, self.from_field())
     }
+
+    pub(crate) fn implicit_fields(&self) -> Vec<&Field> {
+        implicit_fields(&self.fields)
+    }
 }
 
 impl Field<'_> {
     pub(crate) fn is_backtrace(&self) -> bool {
         type_is_backtrace(self.ty)
+    }
+
+    pub(crate) fn is_implicit(&self) -> bool {
+        self.attrs.implicit.is_some()
     }
 
     pub(crate) fn source_span(&self) -> Span {
@@ -145,4 +157,11 @@ fn type_is_backtrace(ty: &Type) -> bool {
 
     let last = path.segments.last().unwrap();
     last.ident == "Backtrace" && last.arguments.is_empty()
+}
+
+fn implicit_fields<'a, 'b>(fields: &'a [Field<'b>]) -> Vec<&'a Field<'b>> {
+    fields
+        .iter()
+        .filter(|field| field.attrs.implicit.is_some())
+        .collect()
 }

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -1,13 +1,12 @@
 use core::error::Error;
+use core::panic::Location;
 #[cfg(feature = "std")]
 use std::sync::Arc;
 
 pub trait ImplicitField {
-    // Required method
     #[track_caller]
     fn generate() -> Self;
 
-    // Provided method
     #[track_caller]
     fn generate_with_source(source: &dyn Error) -> Self
     where
@@ -15,6 +14,13 @@ pub trait ImplicitField {
     {
         let _ = source;
         Self::generate()
+    }
+}
+
+impl ImplicitField for &'static Location<'static> {
+    #[track_caller]
+    fn generate() -> Self {
+        Location::caller()
     }
 }
 

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -1,0 +1,50 @@
+use core::error::Error;
+#[cfg(feature = "std")]
+use std::sync::Arc;
+
+pub trait ImplicitField {
+    // Required method
+    #[track_caller]
+    fn generate() -> Self;
+
+    // Provided method
+    #[track_caller]
+    fn generate_with_source(source: &dyn Error) -> Self
+    where
+        Self: Sized,
+    {
+        let _ = source;
+        Self::generate()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: ImplicitField> ImplicitField for Arc<T> {
+    #[track_caller]
+    fn generate() -> Self {
+        T::generate().into()
+    }
+
+    #[track_caller]
+    fn generate_with_source(source: &dyn Error) -> Self
+    where
+        Self: Sized,
+    {
+        T::generate_with_source(source).into()
+    }
+}
+
+impl<T: ImplicitField> ImplicitField for Option<T> {
+    #[track_caller]
+    fn generate() -> Self {
+        T::generate().into()
+    }
+
+    #[track_caller]
+    fn generate_with_source(source: &dyn Error) -> Self
+    where
+        Self: Sized,
+    {
+        T::generate_with_source(source).into()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,10 +278,12 @@ extern crate std as core;
 
 mod aserror;
 mod display;
+mod implicit;
 #[cfg(error_generic_member_access)]
 mod provide;
 mod var;
 
+pub use implicit::ImplicitField;
 pub use thiserror_impl::*;
 
 // Not public API.

--- a/tests/test_implicit.rs
+++ b/tests/test_implicit.rs
@@ -1,0 +1,99 @@
+use std::{backtrace, sync::Arc};
+
+use thiserror::{Error, ImplicitField};
+
+#[derive(Error, Debug)]
+#[error("Inner")]
+pub struct Inner;
+
+#[derive(Debug)]
+pub struct ImplicitBacktrace(pub backtrace::Backtrace);
+
+impl ImplicitField for ImplicitBacktrace {
+    fn generate() -> Self {
+        Self(backtrace::Backtrace::force_capture())
+    }
+}
+
+#[derive(Debug)]
+pub struct Location(pub &'static core::panic::Location<'static>);
+
+impl Default for Location {
+    #[track_caller]
+    fn default() -> Self {
+        Self(core::panic::Location::caller())
+    }
+}
+
+impl ImplicitField for Location {
+    #[track_caller]
+    fn generate() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("location: {location:?}")]
+pub struct ErrorStruct {
+    #[from]
+    source: Inner,
+    #[implicit]
+    backtrace: ImplicitBacktrace,
+    #[implicit]
+    location: Location,
+    #[implicit]
+    location_arc: Arc<Location>,
+    #[implicit]
+    location_opt: Option<Location>,
+}
+
+#[derive(Error, Debug)]
+#[error("location: {location:?}")]
+pub enum ErrorEnum {
+    #[error("location: {location:?}")]
+    Test {
+        #[from]
+        source: Inner,
+        #[implicit]
+        backtrace: ImplicitBacktrace,
+        #[implicit]
+        location: Location,
+        #[implicit]
+        location_arc: Arc<Location>,
+        #[implicit]
+        location_opt: Option<Location>,
+    },
+}
+
+#[test]
+fn test_implicit() {
+    let base_location = Location::default();
+    let assert_location = |location: &Location| {
+        assert_eq!(location.0.file(), file!(), "location: {location:?}");
+        assert!(
+            location.0.line() > base_location.0.line(),
+            "location: {location:?}"
+        );
+    };
+
+    let error = ErrorStruct::from(Inner);
+    assert_location(&error.location);
+    assert_location(&error.location_arc);
+    assert_location(error.location_opt.as_ref().unwrap());
+    assert_eq!(
+        error.backtrace.0.status(),
+        backtrace::BacktraceStatus::Captured
+    );
+
+    let ErrorEnum::Test {
+        source: _,
+        backtrace,
+        location,
+        location_arc,
+        location_opt,
+    } = ErrorEnum::from(Inner);
+    assert_location(&location);
+    assert_location(&location_arc);
+    assert_location(location_opt.as_ref().unwrap());
+    assert_eq!(backtrace.0.status(), backtrace::BacktraceStatus::Captured);
+}

--- a/tests/ui/from-backtrace-backtrace.stderr
+++ b/tests/ui/from-backtrace-backtrace.stderr
@@ -1,5 +1,7 @@
-error: deriving From requires no fields other than source and backtrace
- --> tests/ui/from-backtrace-backtrace.rs:9:5
-  |
-9 |     #[from]
-  |     ^^^^^^^
+error: only one backtrace field is allowed; found field with #[backtrace] and field with type `Backtrace`
+  --> tests/ui/from-backtrace-backtrace.rs:9:5
+   |
+9  | /     #[from]
+10 | |     #[backtrace]
+11 | |     std::io::Error,
+   | |__________________^


### PR DESCRIPTION
This PR adds a new field attribute called `#[implicit]`. When applied to a field, this attribute causes the derived `From` implementation to initialize the field using a new `ImplicitField` trait. This trait and attribute is inspiried by the [snafu](https://docs.rs/snafu/latest/snafu/) crate. It can be used to automatically derive details such as a backtrace or the location of the error.

Using this field is easy. First implement `ImplicitField` for your type:

```
#[derive(Debug)]
pub struct Location(pub &'static core::panic::Location<'static>);

impl ImplicitField for Location {
    #[track_caller]
    fn generate() -> Self {
        Self(core::panic::Location::caller())
    }
}
```

Then simply add the field to your Error struct or enum variant along with the `#[implicit]` attribute:

```
#[derive(Error, Debug)]
#[error("...")]
pub struct ErrorStruct {
    #[from]
    source: Inner,
    #[implicit]
    location: Location,
}
```

Two important notes:
1. `#[implicit]` fields require a sibling `#[from]` field.
2. `#[implicit]` fields are only auto-generated in the derived `From` implementation. If you create your error another way you will have to initialize the field yourself.

For more comprehensive usage examples including generating Location and Backtrace see this test: https://github.com/carlsverre/thiserror/blob/5195f7ccfa403af3741fd7381ceabd68705426b7/src/implicit.rs

The motivation behind this PR is this blog post https://greptime.com/blogs/2024-05-07-error-rust along with the other feature requests for Location and non-nightly Backtrace support. While `snafu` can be used for this, it has a much larger surface area than `thiserror` and may not be suitable for all projects. This PR shows that with a small change to `thiserror` we can make the library more flexible without too much additional specialization.

If @dtolnay is interested in this feature being polished and landed, I'm happy to put in additional work to make it happen. In addition to more testing and documentation, I suggest that this feature could eventually replace the existing Backtrace/provides code:

1. The existing backtrace logic could be replaced with the more generic implicit system
2. When [`error_generic_member_access`](https://github.com/rust-lang/rust/issues/99301) is available (currently only in nightly) we could provide `#[implicit]` fields by type. If multiple fields match, we could raise an error and have an explicit option on the implicit field.
3. I think the crate could make the above changes in a backwards compatible way by continuing to support the previous field attributes (and implicit Backtrace type detection) and transparently converting them into implicit fields under the hood.