### PR TITLE
Add feature gate to tests that use std

### DIFF
--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -90,6 +90,7 @@ fn test_rustup() {
 }
 
 // Regression test for https://github.com/dtolnay/thiserror/issues/335
+#[cfg(feature = "std")]
 #[test]
 #[allow(non_snake_case)]
 fn test_assoc_type_equality_constraint() {

--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use core::fmt::Display;
 use ref_cast::RefCast;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Forwarded from [Debian](https://salsa.debian.org/Maytha8/debcargo-conf/-/blob/6708e05957603156efa7fd43a196422b56e57d1d/src/thiserror/debian/patches/fix-std-tests.patch).