### PR TITLE
Would it be so bad if you could opt into `#[from]` generating `From<..> for Box<..>`?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.13"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 categories = ["rust-patterns"]
 description = "derive(Error)"
@@ -13,6 +13,7 @@ rust-version = "1.61"
 
 [features]
 default = ["std"]
+autobox = ["std", "thiserror-impl/autobox"]
 
 # Std feature enables support for formatting std::path::{Path, PathBuf}
 # conveniently in an error message.
@@ -28,7 +29,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-thiserror-impl = { version = "=2.0.12", path = "impl" }
+thiserror-impl = { version = "=2.0.13", path = "impl" }
 
 [dev-dependencies]
 anyhow = "1.0.73"

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.13"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 description = "Implementation detail of the `thiserror` crate"
 edition = "2021"
@@ -10,6 +10,10 @@ rust-version = "1.61"
 
 [lib]
 proc-macro = true
+
+[features]
+default = []
+autobox = []
 
 [dependencies]
 proc-macro2 = "1.0.74"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@
 //!   [`anyhow`]: https://github.com/dtolnay/anyhow
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/thiserror/2.0.12")]
+#![doc(html_root_url = "https://docs.rs/thiserror/2.0.13")]
 #![allow(
     clippy::elidable_lifetime_names,
     clippy::module_name_repetitions,

--- a/tests/test_autobox.rs
+++ b/tests/test_autobox.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "autobox")]
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("not great")]
+struct VeryLargeError {
+    a: [u8; 2048],
+}
+
+impl VeryLargeError {
+    fn new() -> Self {
+        Self { a: [0; 2048] }
+    }
+}
+
+#[derive(Debug, Error)]
+enum ErrorEnum {
+    #[error("bad")]
+    Any(#[from] anyhow::Error),
+
+    #[error("worse")]
+    Big(#[from] VeryLargeError),
+}
+
+/// External code may still return large errors...
+fn do_something() -> Result<(), VeryLargeError> {
+    Err(VeryLargeError::new())
+}
+
+/// But we should be able to box them automatically!
+fn do_something_else() -> Result<(), Box<ErrorEnum>> {
+    do_something()?;
+
+    Ok(())
+}
+
+#[test]
+fn autobox() {
+    let _ = do_something_else().unwrap_err();
+}


### PR DESCRIPTION
Hi @dtolnay! Long time listener, first time caller. Please, step into my bikeshed.

I'm looking to change your mind about #57, #302 and #415. I think I understand your position, and I'd like to share mine. I thought that actually bothering to take a crack at it would give me an idea of how burdensome this feature would be to `thiserror`'s users and maintainer.

Anyhow (hah!), I've put together a crude first pass of a new opt-in feature called `autobox`, that, well, automatically boxes `thiserror`-derived (enum only for now) errors, as shown in the new test code:

```rust
#[derive(Debug, Error)]
enum ErrorEnum {
    #[error("bad")]
    Any(#[from] anyhow::Error),

    #[error("worse")]
    Big(#[from] VeryLargeError),
}

/// External code may still return large errors...
fn do_something() -> Result<(), VeryLargeError> {
    Err(VeryLargeError::new())
}

/// But we should be able to box them automatically!
fn do_something_else() -> Result<(), Box<ErrorEnum>> {
    do_something()?;

    Ok(())
}
```

I am sure that you have opinions on the implementation details, but I'm here to argue for this feature being desirable in `thiserror`, even though you've said you don't want it.

Firstly, like the existing `#[from]` implementations, the new feature and derived code is entirely opt in. Indeed, the new code is masked out by a feature flag, so the proc macro does nothing new unless you explicitly ask it to. As such, the new `impl`s won't ever conflict with existing into-box implementations, whether hand-written or derived by another macro.

Secondly, I'd argue that now that Clippy's `result_large_err` is stabilized, more and more people are going to bump into this lint, and therefore there is some "public interest" in the existence of an easy solution that isn't hand-writing the from-for-box impl. Other proc macro crates could certainly achieve the same thing, yes. But, no existing crate, not even `derive_more`, is as convenient or widely trusted as `thiserror`. I don't want to take a dependency on yet another crate for a fairly trivial impl.

Finally, I'd like to say that this new feature doesn't actually require non-trivial changes to `thiserror`s internals, so far as I can tell.

As an aside, I'd like to disarm the anti-Rust crowd who in the future will inevitably wheel out the "look at all those needless `memcpy`s" strawman.