### PR TITLE
Add attribute #[boxing] to allow automatic boxing

### DIFF
--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -191,6 +191,32 @@ fn impl_struct(input: Struct) -> TokenStream {
         })
     });
 
+    let boxing_impl = input.boxing_field().map(|from_field| {
+        let span = from_field.attrs.from.unwrap().span;
+        let from = unoptional_type(from_field.ty);
+        let source_var = Ident::new("source", span);
+        let from_function = quote! {
+            fn from(#source_var: #from) -> Self {
+                ::std::boxed::Box::new(From::from(#source_var))
+            }
+        };
+        let boxing_impl = quote_spanned! {span=>
+            #[automatically_derived]
+            impl #impl_generics ::core::convert::From<#from> for ::std::boxed::Box < #ty #ty_generics > #where_clause {
+                #from_function
+            }
+        };
+        Some(quote! {
+            #[allow(
+                deprecated,
+                unused_qualifications,
+                clippy::elidable_lifetime_names,
+                clippy::needless_lifetimes,
+            )]
+            #boxing_impl
+        })
+    });
+
     if input.generics.type_params().next().is_some() {
         let self_token = <Token![Self]>::default();
         error_inferred_bounds.insert(self_token, Trait::Debug);
@@ -207,6 +233,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         }
         #display_impl
         #from_impl
+        #boxing_impl
     }
 }
 
@@ -466,6 +493,33 @@ fn impl_enum(input: Enum) -> TokenStream {
         })
     });
 
+    let boxing_impls = input.variants.iter().filter_map(|variant| {
+        let from_field = variant.boxing_field()?;
+        let span = from_field.attrs.boxing.unwrap().span;
+        let from = unoptional_type(from_field.ty);
+        let source_var = Ident::new("source", span);
+        let from_function = quote! {
+            fn from(#source_var: #from) -> Self {
+                ::std::boxed::Box::new(From::from(#source_var))
+            }
+        };
+        let from_impl = quote_spanned! {span=>
+            #[automatically_derived]
+            impl #impl_generics ::core::convert::From<#from> for ::std::boxed::Box < #ty #ty_generics > #where_clause {
+                #from_function
+            }
+        };
+        Some(quote! {
+            #[allow(
+                deprecated,
+                unused_qualifications,
+                clippy::elidable_lifetime_names,
+                clippy::needless_lifetimes,
+            )]
+            #from_impl
+        })
+    });
+
     if input.generics.type_params().next().is_some() {
         let self_token = <Token![Self]>::default();
         error_inferred_bounds.insert(self_token, Trait::Debug);
@@ -482,6 +536,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         }
         #display_impl
         #(#from_impls)*
+        #(#boxing_impls)*
     }
 }
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -33,7 +33,7 @@ mod valid;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-#[proc_macro_derive(Error, attributes(backtrace, error, from, source))]
+#[proc_macro_derive(Error, attributes(backtrace, error, from, source, boxing))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input).into()

--- a/impl/src/prop.rs
+++ b/impl/src/prop.rs
@@ -20,6 +20,10 @@ impl Struct<'_> {
         let backtrace_field = self.backtrace_field()?;
         distinct_backtrace_field(backtrace_field, self.from_field())
     }
+
+    pub(crate) fn boxing_field(&self) -> Option<&Field> {
+        boxing_field(&self.fields)
+    }
 }
 
 impl Enum<'_> {
@@ -66,6 +70,10 @@ impl Variant<'_> {
     pub(crate) fn distinct_backtrace_field(&self) -> Option<&Field> {
         let backtrace_field = self.backtrace_field()?;
         distinct_backtrace_field(backtrace_field, self.from_field())
+    }
+
+    pub(crate) fn boxing_field(&self) -> Option<&Field> {
+        boxing_field(&self.fields)
     }
 }
 
@@ -135,6 +143,12 @@ fn distinct_backtrace_field<'a, 'b>(
     } else {
         Some(backtrace_field)
     }
+}
+
+fn boxing_field<'a, 'b>(fields: &'a [Field<'b>]) -> Option<&'a Field<'b>> {
+    fields
+        .iter()
+        .find(|Field { attrs, .. }| attrs.from.is_some() && attrs.boxing.is_some())
 }
 
 fn type_is_backtrace(ty: &Type) -> bool {

--- a/impl/src/valid.rs
+++ b/impl/src/valid.rs
@@ -145,6 +145,13 @@ fn check_non_field_attrs(attrs: &Attrs) -> Result<()> {
         ));
     }
 
+    if let Some(boxing) = &attrs.boxing {
+        return Err(Error::new_spanned(
+            boxing.original,
+            "attribute #[boxing] expected on a specific field also having #[from] attribute ",
+        ));
+    }
+
     Ok(())
 }
 
@@ -153,6 +160,7 @@ fn check_field_attrs(fields: &[Field]) -> Result<()> {
     let mut source_field = None;
     let mut backtrace_field = None;
     let mut has_backtrace = false;
+    let mut boxing_field = None;
     for field in fields {
         if let Some(from) = field.attrs.from {
             if from_field.is_some() {
@@ -189,6 +197,16 @@ fn check_field_attrs(fields: &[Field]) -> Result<()> {
             ));
         }
         has_backtrace |= field.is_backtrace();
+
+        if let Some(boxing) = field.attrs.boxing {
+            if boxing_field.is_some() {
+                return Err(Error::new_spanned(
+                    boxing.original,
+                    "duplicate #[boxing] attribute",
+                ));
+            }
+            boxing_field = Some(field);
+        }
     }
     if let (Some(from_field), Some(source_field)) = (from_field, source_field) {
         if from_field.member != source_field.member {
@@ -218,6 +236,14 @@ fn check_field_attrs(fields: &[Field]) -> Result<()> {
             ));
         }
     }
+
+    if let (None, Some(boxing_field)) = (from_field, boxing_field) {
+        return Err(Error::new_spanned(
+            boxing_field.attrs.boxing.unwrap().original,
+            "attribute #[boxing] requires the field to also have a #[from] attribute",
+        ));
+    }
+
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,41 @@
 //!   }
 //!   ```
 //!
+//! - Additionally, the `#[from]` attribute may be augmented with a `#[boxing]` attribute, for conveniently boxing source errors:
+//!   This is especially useful for ensuring large source errors do not needlessly enlarge every stack frame in which they may be used.
+//!   See also: <https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err>.
+//!
+//!   ```
+//!   # use thiserror::Error;
+//!   #
+//!   #[derive(Error, Debug)]
+//!   #[error("...")]
+//!   pub struct ExternalError([u8; 2048]);
+//!
+//!   #[derive(Error, Debug)]
+//!   pub enum MyError {
+//!       #[error(transparent)]
+//!       ExternalCause(#[from] #[boxing] ExternalError),
+//!
+//!       #[error("other")]
+//!       Other,
+//!   }
+//!
+//!   pub fn do_something() -> Result<(), ExternalError> {
+//!       # /*
+//!       ...
+//!       # */
+//!       # Ok(())
+//!   }
+//!
+//!   // Automatically boxed
+//!   pub fn something_else() -> Result<(), Box<MyError>> {
+//!       do_something()?;
+//!
+//!       Ok(())
+//!   }
+//!   ```
+//!
 //! - See also the [`anyhow`] library for a convenient single error type to use
 //!   in application code.
 //!

--- a/tests/test_boxing.rs
+++ b/tests/test_boxing.rs
@@ -1,0 +1,132 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub struct LargeError {
+    a: [u8; 2048],
+}
+
+pub fn direct_return_large() -> Result<(), LargeError> {
+    Err(LargeError { a: [0; 2048] })
+}
+
+pub fn non_boxed() -> Result<(), Autoboxed> {
+    let _ = direct_return_large()?;
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub enum Autoboxed {
+    Large(
+        #[from]
+        #[boxing]
+        LargeError,
+    ),
+}
+
+pub fn autobox() -> Result<(), Box<Autoboxed>> {
+    let _ = direct_return_large()?;
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub struct Autoboxed2 {
+    #[from]
+    #[boxing]
+    err: LargeError,
+}
+
+pub fn autobox2() -> Result<(), Box<Autoboxed2>> {
+    let _ = direct_return_large()?;
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub struct Autoboxed3 {
+    #[boxing]
+    #[from]
+    err: LargeError,
+}
+
+pub fn autobox3() -> Result<(), Box<Autoboxed3>> {
+    let _ = direct_return_large()?;
+
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub enum Multiple {
+    #[error(transparent)]
+    A(
+        #[from]
+        #[boxing]
+        LargeError,
+    ),
+
+    #[error(transparent)]
+    B {
+        #[from]
+        #[boxing]
+        named_field: std::io::Error,
+    },
+}
+
+pub fn std_fallible() -> std::io::Result<()> {
+    unimplemented!()
+}
+
+pub fn boxes_both() -> Result<(), Box<Multiple>> {
+    let _ = direct_return_large()?;
+    let _ = std_fallible()?;
+
+    Ok(())
+}
+
+/// Deliberatly contrived typed to exercise the lifetimes and generics part of the proc macro.
+pub trait Origin<'a>: std::error::Error {
+    fn origin(&self) -> &'a str;
+}
+
+#[derive(Debug, Error)]
+#[error("origin {0}")]
+pub struct SomeOrigin<'a>(&'a str);
+
+impl<'a> Origin<'a> for SomeOrigin<'a> {
+    fn origin(&self) -> &'a str {
+        self.0
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SomeErr<'a, T>
+where
+    T: Origin<'a>,
+{
+    #[error("...")]
+    A(
+        #[from]
+        #[boxing]
+        T,
+    ),
+
+    #[error("...")]
+    B(&'a str),
+}
+
+pub fn bad_thing<'a>(input: &'a str) -> Result<(), SomeOrigin<'a>> {
+    Err(SomeOrigin(input))
+}
+
+pub fn boxing_with_lifetimes_and_generics<'a>(
+    input: &'a str,
+) -> Result<(), Box<SomeErr<'a, SomeOrigin<'a>>>> {
+    let _ = bad_thing(input)?;
+    Ok(())
+}

--- a/tests/ui/boxing-dups.rs
+++ b/tests/ui/boxing-dups.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Dups {
+    #[error(transparent)]
+    Twice(#[boxing] #[boxing] #[from] std::io::Error),
+}
+
+fn main() {}

--- a/tests/ui/boxing-dups.stderr
+++ b/tests/ui/boxing-dups.stderr
@@ -1,0 +1,5 @@
+error: duplicate #[boxing] attribute
+ --> tests/ui/boxing-dups.rs:6:21
+  |
+6 |     Twice(#[boxing] #[boxing] #[from] std::io::Error),
+  |                     ^^^^^^^^^

--- a/tests/ui/boxing-missing-from.rs
+++ b/tests/ui/boxing-missing-from.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Missing {
+    #[error(transparent)]
+    NotThere(#[boxing] std::io::Error),
+}
+
+#[derive(Error, Debug)]
+#[error("...")]
+pub struct AlsoMissing {
+    #[boxing] err: std::io::Error,
+}
+
+fn main() {}

--- a/tests/ui/boxing-missing-from.stderr
+++ b/tests/ui/boxing-missing-from.stderr
@@ -1,0 +1,11 @@
+error: attribute #[boxing] requires the field to also have a #[from] attribute
+ --> tests/ui/boxing-missing-from.rs:6:14
+  |
+6 |     NotThere(#[boxing] std::io::Error),
+  |              ^^^^^^^^^
+
+error: attribute #[boxing] requires the field to also have a #[from] attribute
+  --> tests/ui/boxing-missing-from.rs:12:5
+   |
+12 |     #[boxing] err: std::io::Error,
+   |     ^^^^^^^^^

--- a/tests/ui/boxing-wrong-position.rs
+++ b/tests/ui/boxing-wrong-position.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("...")]
+#[boxing]
+pub struct AlsoMissing {
+    #[from] err: std::io::Error,
+}
+
+fn main() {}

--- a/tests/ui/boxing-wrong-position.stderr
+++ b/tests/ui/boxing-wrong-position.stderr
@@ -1,0 +1,5 @@
+error: attribute #[boxing] expected on a specific field also having #[from] attribute
+ --> tests/ui/boxing-wrong-position.rs:5:1
+  |
+5 | #[boxing]
+  | ^^^^^^^^^


### PR DESCRIPTION
Following up on #418, I've got a better strategy and a complete implementation of what it would look like for `thiserror` to allow you to opt-into generating impl-from-for-box. I have defined a new attribute, `#[boxing]` which can be used like so:

```rust
#[derive(Error, Debug)]
#[error("...")]
pub struct Autoboxed2 {
    #[from]
    #[boxing]
    err: LargeError,
}

pub fn autobox2() -> Result<(), Box<Autoboxed2>> {
    let _ = direct_return_large()?; // no more .map_err(Box::new)!

    Ok(())
}
```

The PR also includes a number of `trybuild`-based tests and an example in the RustDoc.

The new attribute is truly opt-in, because it must appear for each field or variant on which it is used. I chose to create a new attribute, rather than to extend the `from` attribute. My reasoning is based on the "public interest" (#418) in having `thiserror` automatically box errors. Overriding `#[from]`  with arguments would complicate `thiserror`. Richer `From` implementations are already achievable with `derive_more`.

