### PR TITLE
Ignore new dead code warning from rustc nightly-2025-07-14

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -60,6 +60,7 @@ mod placeholder {
     use super::{AsDisplay, Sealed};
     use core::fmt::{self, Display};
 
+    #[allow(dead_code)]
     pub struct Placeholder;
 
     impl<'a> AsDisplay<'a> for Placeholder {


### PR DESCRIPTION
- https://github.com/rust-lang/rust/pull/143519

```console
warning: struct `Placeholder` is never constructed
  --> src/display.rs:63:16
   |
63 |     pub struct Placeholder;
   |                ^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```