### PR TITLE
Add links to more items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,14 +38,14 @@
 //! # Details
 //!
 //! - Thiserror deliberately does not appear in your public API. You get the
-//!   same thing as if you had written an implementation of `std::error::Error`
+//!   same thing as if you had written an implementation of [`std::error::Error`]
 //!   by hand, and switching from handwritten impls to thiserror or vice versa
 //!   is not a breaking change.
 //!
 //! - Errors may be enums, structs with named fields, tuple structs, or unit
 //!   structs.
 //!
-//! - A `Display` impl is generated for your error if you provide
+//! - A [`Display`] impl is generated for your error if you provide
 //!   `#[error("...")]` messages on the struct or each variant of your enum, as
 //!   shown above in the example.
 //!
@@ -96,7 +96,7 @@
 //!   }
 //!   ```
 //!
-//! - A `From` impl is generated for each variant that contains a `#[from]`
+//! - A [`From`] impl is generated for each variant that contains a `#[from]`
 //!   attribute.
 //!
 //!   The variant using `#[from]` must not contain any other fields beyond the
@@ -128,7 +128,7 @@
 //!   # }
 //!   ```
 //!
-//! - The Error trait's `source()` method is implemented to return whichever
+//! - The Error trait's [`source()`] method is implemented to return whichever
 //!   field has a `#[source]` attribute or is named `source`, if any. This is
 //!   for identifying the underlying lower level error that caused your error.
 //!
@@ -156,9 +156,9 @@
 //!   # }
 //!   ```
 //!
-//! - The Error trait's `provide()` method is implemented to provide whichever
+//! - The Error trait's [`provide()`] method is implemented to provide whichever
 //!   field has a type named `Backtrace`, if any, as a
-//!   `std::backtrace::Backtrace`. Using `Backtrace` in errors requires a
+//!   [`std::backtrace::Backtrace`]. Using `Backtrace` in errors requires a
 //!   nightly compiler with Rust version 1.73 or newer.
 //!
 //!   ```rust
@@ -175,7 +175,7 @@
 //!
 //! - If a field is both a source (named `source`, or has `#[source]` or
 //!   `#[from]` attribute) *and* is marked `#[backtrace]`, then the Error
-//!   trait's `provide()` method is forwarded to the source's `provide` so that
+//!   trait's [`provide()`] method is forwarded to the source's `provide` so that
 //!   both layers of the error share the same backtrace. The `#[backtrace]`
 //!   attribute requires a nightly compiler with Rust version 1.73 or newer.
 //!
@@ -207,7 +207,7 @@
 //!   # };
 //!   ```
 //!
-//! - Errors may use `error(transparent)` to forward the source and Display
+//! - Errors may use `error(transparent)` to forward the source and [`Display`]
 //!   methods straight through to an underlying error without adding an
 //!   additional message. This would be appropriate for enums that need an
 //!   "anything else" variant.
@@ -255,6 +255,9 @@
 //!   in application code.
 //!
 //!   [`anyhow`]: https://github.com/dtolnay/anyhow
+//!   [`source()`]: std::error::Error::source
+//!   [`provide()`]: std::error::Error::provide
+//!   [`Display`]: std::fmt::Display
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/thiserror/2.0.12")]


### PR DESCRIPTION
Especially for less used items like `source()` and `provide()` it can be very useful to click through to see what they do.

I've also added links to some more items, but not all. I kept it to one link per item per block of text, to prevent cluttering the text.

Let me know if you want more or less links.