### PR TITLE
Exclude compile tests from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["error", "error-handling", "derive"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/thiserror"
 rust-version = "1.61"
+include = ["src/**/*.rs", "Cargo.toml", "build.rs", "build/probe.rs", "tests/test_*.rs", "LICENSE-APACHE", "LICENSE-MIT"]
 
 [features]
 default = ["std"]


### PR DESCRIPTION
During a dependency review I noticed that thiserror includes the output of it's compile tests in the published package. These files are not required for building thiserror as dependency and make it a bit harder to review the code.

This commit introduces a `include` directive in the `Cargo.toml` file to explicitly include only those files required to build `thiserror`. This excludes the compile test artifacts and also reduces the size of the published crate from 105 files, 113.9KiB (28.2KiB compressed) to 26 files, 86.6KiB (21.5KiB compressed) which results in a 217GB/Month traffic reduction for crates.io assuming the current 34 million downloads and the difference in the compressed package size.

---

Completely removing the tests would reduce the package size to 15 files, 49.1KiB (14.9KiB compressed), although I'm not sure if you are open to do that.