### PR TITLE
Fix documentation example for transparent error pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ pub enum DataStoreError {
   // Private and free to change across minor version of the crate.
   #[derive(Error, Debug)]
   enum ErrorRepr {
-      ...
+      #[error("invalid input")]
+      InvalidInput(#[from] InvalidInputError),
+      // Additional error variants can be added here
   }
   ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,10 +245,22 @@
 //!   // Private and free to change across minor version of the crate.
 //!   #[derive(Error, Debug)]
 //!   enum ErrorRepr {
-//!       # /*
-//!       ...
-//!       # */
+//!       #[error("invalid input")]
+//!       InvalidInput(#[from] InvalidInputError),
 //!   }
+//!   #
+//!   # #[derive(Error, Debug)]
+//!   # #[error("invalid input")]
+//!   # struct InvalidInputError;
+//!   #
+//!   # fn process() -> Result<(), ErrorRepr> {
+//!   #     Err(InvalidInputError.into())
+//!   # }
+//!   #
+//!   # fn example() -> Result<(), PublicError> {
+//!   #     process()?;
+//!   #     Ok(())
+//!   # }
 //!   ```
 //!
 //! - See also the [`anyhow`] library for a convenient single error type to use


### PR DESCRIPTION
The documentation example showing how to use `#[error(transparent)]` with `#[from]` on a struct wrapping an enum had a placeholder (`...`) that caused compilation errors when users tried to complete it.

## Changes
- Replaced the placeholder with a concrete example showing an error variant with `#[from]`
- Added hidden helper code demonstrating the `From` trait chain works correctly
- Included a working example function using the `?` operator

## Key Detail
The important pattern shown is that intermediate functions should return `Result<(), ErrorRepr>` so the conversion chain works: `InvalidInputError` → `ErrorRepr` → `PublicError`

## Testing
- All doc tests pass
- All existing tests pass

Fixes #439