### PR TITLE
Add #[thiserror(crate = "...")] attribute for re-export scenarios

### DIFF
--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -5,7 +5,7 @@ use syn::parse::discouraged::Speculative;
 use syn::parse::{End, ParseStream};
 use syn::{
     braced, bracketed, parenthesized, token, Attribute, Error, ExprPath, Ident, Index, LitFloat,
-    LitInt, LitStr, Meta, Result, Token,
+    LitInt, LitStr, Meta, Path, Result, Token,
 };
 
 pub struct Attrs<'a> {
@@ -15,6 +15,7 @@ pub struct Attrs<'a> {
     pub from: Option<From<'a>>,
     pub transparent: Option<Transparent<'a>>,
     pub fmt: Option<Fmt<'a>>,
+    pub crate_path: Option<Path>,
 }
 
 #[derive(Clone)]
@@ -74,6 +75,7 @@ pub fn get(input: &[Attribute]) -> Result<Attrs> {
         from: None,
         transparent: None,
         fmt: None,
+        crate_path: None,
     };
 
     for attr in input {
@@ -115,10 +117,43 @@ pub fn get(input: &[Attribute]) -> Result<Attrs> {
                 original: attr,
                 span,
             });
+        } else if attr.path().is_ident("thiserror") {
+            attr.parse_nested_meta(|meta| {
+                if !meta.path.is_ident("crate") {
+                    let path_str = meta.path.to_token_stream().to_string().replace(' ', "");
+                    return Err(
+                        meta.error(format_args!("unknown thiserror attribute `{path_str}`"))
+                    );
+                }
+                let crate_path_lit: LitStr = meta.value()?.parse()?;
+                let path = crate_path_lit
+                    .parse::<Path>()
+                    .map_err(|e| Error::new(crate_path_lit.span(), e))?;
+                if attrs.crate_path.is_some() {
+                    return Err(Error::new_spanned(
+                        attr,
+                        "duplicate #[thiserror(crate)] attribute",
+                    ));
+                }
+                attrs.crate_path = Some(path);
+                Ok(())
+            })?;
         }
     }
 
     Ok(attrs)
+}
+
+/// Extract the thiserror crate path from `#[thiserror(crate = "...")]` on the container,
+/// defaulting to `::thiserror` if the attribute is absent or malformed.
+///
+/// # Returns
+/// The explicit crate path if provided, otherwise `::thiserror`.
+pub fn crate_path(attrs: &[Attribute]) -> syn::Path {
+    get(attrs)
+        .ok()
+        .and_then(|a| a.crate_path)
+        .unwrap_or_else(|| syn::parse_quote!(::thiserror))
 }
 
 fn parse_error_attribute<'a>(attrs: &mut Attrs<'a>, attr: &'a Attribute) -> Result<()> {

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -144,11 +144,6 @@ pub fn get(input: &[Attribute]) -> Result<Attrs> {
     Ok(attrs)
 }
 
-/// Extract the thiserror crate path from `#[thiserror(crate = "...")]` on the container,
-/// defaulting to `::thiserror` if the attribute is absent or malformed.
-///
-/// # Returns
-/// The explicit crate path if provided, otherwise `::thiserror`.
 pub fn crate_path(attrs: &[Attribute]) -> syn::Path {
     get(attrs)
         .ok()

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -7,7 +7,7 @@ use crate::unraw::MemberUnraw;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use std::collections::BTreeSet as Set;
-use syn::{DeriveInput, GenericArgument, PathArguments, Result, Token, Type};
+use syn::{DeriveInput, GenericArgument, Path, PathArguments, Result, Token, Type};
 
 pub fn derive(input: &DeriveInput) -> TokenStream {
     match try_expand(input) {
@@ -32,21 +32,26 @@ fn impl_struct(input: Struct) -> TokenStream {
     let ty = call_site_ident(&input.ident);
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let mut error_inferred_bounds = InferredBounds::new();
+    let krate: Path = input
+        .attrs
+        .crate_path
+        .clone()
+        .unwrap_or_else(|| syn::parse_quote!(::thiserror));
 
     let source_body = if let Some(transparent_attr) = &input.attrs.transparent {
         let only_field = &input.fields[0];
         if only_field.contains_generic {
-            error_inferred_bounds.insert(only_field.ty, quote!(::thiserror::#private::Error));
+            error_inferred_bounds.insert(only_field.ty, quote!(#krate::#private::Error));
         }
         let member = &only_field.member;
         Some(quote_spanned! {transparent_attr.span=>
-            ::thiserror::#private::Error::source(self.#member.as_dyn_error())
+            #krate::#private::Error::source(self.#member.as_dyn_error())
         })
     } else if let Some(source_field) = input.source_field() {
         let source = &source_field.member;
         if source_field.contains_generic {
             let ty = unoptional_type(source_field.ty);
-            error_inferred_bounds.insert(ty, quote!(::thiserror::#private::Error + 'static));
+            error_inferred_bounds.insert(ty, quote!(#krate::#private::Error + 'static));
         }
         let asref = if type_is_option(source_field.ty) {
             Some(quote_spanned!(source.span()=> .as_ref()?))
@@ -64,8 +69,8 @@ fn impl_struct(input: Struct) -> TokenStream {
     };
     let source_method = source_body.map(|body| {
         quote! {
-            fn source(&self) -> ::core::option::Option<&(dyn ::thiserror::#private::Error + 'static)> {
-                use ::thiserror::#private::AsDynError as _;
+            fn source(&self) -> ::core::option::Option<&(dyn #krate::#private::Error + 'static)> {
+                use #krate::#private::AsDynError as _;
                 #body
             }
         }
@@ -92,28 +97,28 @@ fn impl_struct(input: Struct) -> TokenStream {
             } else if type_is_option(backtrace_field.ty) {
                 Some(quote! {
                     if let ::core::option::Option::Some(backtrace) = &self.#backtrace {
-                        #request.provide_ref::<::thiserror::#private::Backtrace>(backtrace);
+                        #request.provide_ref::<#krate::#private::Backtrace>(backtrace);
                     }
                 })
             } else {
                 Some(quote! {
-                    #request.provide_ref::<::thiserror::#private::Backtrace>(&self.#backtrace);
+                    #request.provide_ref::<#krate::#private::Backtrace>(&self.#backtrace);
                 })
             };
             quote! {
-                use ::thiserror::#private::ThiserrorProvide as _;
+                use #krate::#private::ThiserrorProvide as _;
                 #source_provide
                 #self_provide
             }
         } else if type_is_option(backtrace_field.ty) {
             quote! {
                 if let ::core::option::Option::Some(backtrace) = &self.#backtrace {
-                    #request.provide_ref::<::thiserror::#private::Backtrace>(backtrace);
+                    #request.provide_ref::<#krate::#private::Backtrace>(backtrace);
                 }
             }
         } else {
             quote! {
-                #request.provide_ref::<::thiserror::#private::Backtrace>(&self.#backtrace);
+                #request.provide_ref::<#krate::#private::Backtrace>(&self.#backtrace);
             }
         };
         quote! {
@@ -132,7 +137,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         })
     } else if let Some(display) = &input.attrs.display {
         display_implied_bounds.clone_from(&display.implied_bounds);
-        let use_as_display = use_as_display(display.has_bonus_display);
+        let use_as_display = use_as_display(display.has_bonus_display, &krate);
         let pat = fields_pat(&input.fields);
         Some(quote! {
             #use_as_display
@@ -169,7 +174,7 @@ fn impl_struct(input: Struct) -> TokenStream {
         let backtrace_field = input.distinct_backtrace_field();
         let from = unoptional_type(from_field.ty);
         let source_var = Ident::new("source", span);
-        let body = from_initializer(from_field, backtrace_field, &source_var);
+        let body = from_initializer(from_field, backtrace_field, &source_var, &krate);
         let from_function = quote! {
             fn from(#source_var: #from) -> Self {
                 #ty #body
@@ -209,7 +214,7 @@ fn impl_struct(input: Struct) -> TokenStream {
     quote! {
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics ::thiserror::#private::Error for #ty #ty_generics #error_where_clause {
+        impl #impl_generics #krate::#private::Error for #ty #ty_generics #error_where_clause {
             #source_method
             #provide_method
         }
@@ -222,6 +227,11 @@ fn impl_enum(input: Enum) -> TokenStream {
     let ty = call_site_ident(&input.ident);
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let mut error_inferred_bounds = InferredBounds::new();
+    let krate: Path = input
+        .attrs
+        .crate_path
+        .clone()
+        .unwrap_or_else(|| syn::parse_quote!(::thiserror));
 
     let source_method = if input.has_source() {
         let arms = input.variants.iter().map(|variant| {
@@ -229,11 +239,11 @@ fn impl_enum(input: Enum) -> TokenStream {
             if let Some(transparent_attr) = &variant.attrs.transparent {
                 let only_field = &variant.fields[0];
                 if only_field.contains_generic {
-                    error_inferred_bounds.insert(only_field.ty, quote!(::thiserror::#private::Error));
+                    error_inferred_bounds.insert(only_field.ty, quote!(#krate::#private::Error));
                 }
                 let member = &only_field.member;
                 let source = quote_spanned! {transparent_attr.span=>
-                    ::thiserror::#private::Error::source(transparent.as_dyn_error())
+                    #krate::#private::Error::source(transparent.as_dyn_error())
                 };
                 quote! {
                     #ty::#ident {#member: transparent} => #source,
@@ -242,7 +252,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                 let source = &source_field.member;
                 if source_field.contains_generic {
                     let ty = unoptional_type(source_field.ty);
-                    error_inferred_bounds.insert(ty, quote!(::thiserror::#private::Error + 'static));
+                    error_inferred_bounds.insert(ty, quote!(#krate::#private::Error + 'static));
                 }
                 let asref = if type_is_option(source_field.ty) {
                     Some(quote_spanned!(source.span()=> .as_ref()?))
@@ -263,8 +273,8 @@ fn impl_enum(input: Enum) -> TokenStream {
             }
         });
         Some(quote! {
-            fn source(&self) -> ::core::option::Option<&(dyn ::thiserror::#private::Error + 'static)> {
-                use ::thiserror::#private::AsDynError as _;
+            fn source(&self) -> ::core::option::Option<&(dyn #krate::#private::Error + 'static)> {
+                use #krate::#private::AsDynError as _;
                 #[allow(deprecated)]
                 match self {
                     #(#arms)*
@@ -300,12 +310,12 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let self_provide = if type_is_option(backtrace_field.ty) {
                         quote! {
                             if let ::core::option::Option::Some(backtrace) = backtrace {
-                                #request.provide_ref::<::thiserror::#private::Backtrace>(backtrace);
+                                #request.provide_ref::<#krate::#private::Backtrace>(backtrace);
                             }
                         }
                     } else {
                         quote! {
-                            #request.provide_ref::<::thiserror::#private::Backtrace>(backtrace);
+                            #request.provide_ref::<#krate::#private::Backtrace>(backtrace);
                         }
                     };
                     quote! {
@@ -314,7 +324,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                             #source: #varsource,
                             ..
                         } => {
-                            use ::thiserror::#private::ThiserrorProvide as _;
+                            use #krate::#private::ThiserrorProvide as _;
                             #source_provide
                             #self_provide
                         }
@@ -338,7 +348,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                     };
                     quote! {
                         #ty::#ident {#backtrace: #varsource, ..} => {
-                            use ::thiserror::#private::ThiserrorProvide as _;
+                            use #krate::#private::ThiserrorProvide as _;
                             #source_provide
                         }
                     }
@@ -348,12 +358,12 @@ fn impl_enum(input: Enum) -> TokenStream {
                     let body = if type_is_option(backtrace_field.ty) {
                         quote! {
                             if let ::core::option::Option::Some(backtrace) = backtrace {
-                                #request.provide_ref::<::thiserror::#private::Backtrace>(backtrace);
+                                #request.provide_ref::<#krate::#private::Backtrace>(backtrace);
                             }
                         }
                     } else {
                         quote! {
-                            #request.provide_ref::<::thiserror::#private::Backtrace>(backtrace);
+                            #request.provide_ref::<#krate::#private::Backtrace>(backtrace);
                         }
                     };
                     quote! {
@@ -387,7 +397,7 @@ fn impl_enum(input: Enum) -> TokenStream {
                 .as_ref()
                 .is_some_and(|display| display.has_bonus_display)
         });
-        let use_as_display = use_as_display(has_bonus_display);
+        let use_as_display = use_as_display(has_bonus_display, &krate);
         let void_deref = if input.variants.is_empty() {
             Some(quote!(*))
         } else {
@@ -451,7 +461,7 @@ fn impl_enum(input: Enum) -> TokenStream {
         let variant = &variant.ident;
         let from = unoptional_type(from_field.ty);
         let source_var = Ident::new("source", span);
-        let body = from_initializer(from_field, backtrace_field, &source_var);
+        let body = from_initializer(from_field, backtrace_field, &source_var, &krate);
         let from_function = quote! {
             fn from(#source_var: #from) -> Self {
                 #ty::#variant #body
@@ -491,7 +501,7 @@ fn impl_enum(input: Enum) -> TokenStream {
     quote! {
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics ::thiserror::#private::Error for #ty #ty_generics #error_where_clause {
+        impl #impl_generics #krate::#private::Error for #ty #ty_generics #error_where_clause {
             #source_method
             #provide_method
         }
@@ -523,10 +533,10 @@ fn fields_pat(fields: &[Field]) -> TokenStream {
     }
 }
 
-fn use_as_display(needs_as_display: bool) -> Option<TokenStream> {
+fn use_as_display(needs_as_display: bool, krate: &Path) -> Option<TokenStream> {
     if needs_as_display {
         Some(quote! {
-            use ::thiserror::#private::AsDisplay as _;
+            use #krate::#private::AsDisplay as _;
         })
     } else {
         None
@@ -537,6 +547,7 @@ fn from_initializer(
     from_field: &Field,
     backtrace_field: Option<&Field>,
     source_var: &Ident,
+    krate: &Path,
 ) -> TokenStream {
     let from_member = &from_field.member;
     let some_source = if type_is_option(from_field.ty) {
@@ -548,11 +559,11 @@ fn from_initializer(
         let backtrace_member = &backtrace_field.member;
         if type_is_option(backtrace_field.ty) {
             quote! {
-                #backtrace_member: ::core::option::Option::Some(::thiserror::#private::Backtrace::capture()),
+                #backtrace_member: ::core::option::Option::Some(#krate::#private::Backtrace::capture()),
             }
         } else {
             quote! {
-                #backtrace_member: ::core::convert::From::from(::thiserror::#private::Backtrace::capture()),
+                #backtrace_member: ::core::convert::From::from(#krate::#private::Backtrace::capture()),
             }
         }
     });

--- a/impl/src/fallback.rs
+++ b/impl/src/fallback.rs
@@ -7,6 +7,7 @@ use syn::DeriveInput;
 pub(crate) fn expand(input: &DeriveInput, error: syn::Error) -> TokenStream {
     let ty = call_site_ident(&input.ident);
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let krate = crate::attr::crate_path(&input.attrs);
 
     let error = error.to_compile_error();
 
@@ -15,7 +16,7 @@ pub(crate) fn expand(input: &DeriveInput, error: syn::Error) -> TokenStream {
 
         #[allow(unused_qualifications)]
         #[automatically_derived]
-        impl #impl_generics ::thiserror::#private::Error for #ty #ty_generics #where_clause
+        impl #impl_generics #krate::#private::Error for #ty #ty_generics #where_clause
         where
             // Work around trivial bounds being unstable.
             // https://github.com/rust-lang/rust/issues/48214

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -36,7 +36,7 @@ use proc_macro2::{Ident, Span};
 use quote::{ToTokens, TokenStreamExt as _};
 use syn::{parse_macro_input, DeriveInput};
 
-#[proc_macro_derive(Error, attributes(backtrace, error, from, source))]
+#[proc_macro_derive(Error, attributes(backtrace, error, from, source, thiserror))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input).into()

--- a/tests/test_crate_path.rs
+++ b/tests/test_crate_path.rs
@@ -1,0 +1,142 @@
+//! Tests for `#[thiserror(crate = "...")]` — the attribute that lets a
+//! consuming crate redirect the generated `::thiserror::__private::…` paths
+//! to a re-exported copy of thiserror.
+
+// Simulate the scenario where `thiserror` is only accessible through a
+// re-exporting wrapper crate, not as a top-level dependency.
+mod reexport {
+    #[doc(hidden)]
+    pub use thiserror;
+    #[doc(hidden)]
+    pub use thiserror::*;
+}
+
+// --- struct: basic re-export path ---
+
+#[derive(reexport::Error, Debug)]
+#[thiserror(crate = "reexport::thiserror")]
+#[error("struct error: {msg}")]
+struct StructError {
+    msg: String,
+}
+
+#[test]
+fn test_struct_display() {
+    let e = StructError { msg: "boom".into() };
+    assert_eq!(e.to_string(), "struct error: boom");
+}
+
+#[test]
+fn test_struct_is_error() {
+    let e = StructError { msg: "boom".into() };
+    let _: &dyn std::error::Error = &e;
+}
+
+// --- enum: basic re-export path ---
+
+#[derive(reexport::Error, Debug)]
+#[thiserror(crate = "reexport::thiserror")]
+enum EnumError {
+    #[error("variant a")]
+    A,
+    #[error("variant b: {0}")]
+    B(u32),
+}
+
+#[test]
+fn test_enum_display_unit() {
+    assert_eq!(EnumError::A.to_string(), "variant a");
+}
+
+#[test]
+fn test_enum_display_tuple() {
+    assert_eq!(EnumError::B(42).to_string(), "variant b: 42");
+}
+
+#[test]
+fn test_enum_is_error() {
+    let _: &dyn std::error::Error = &EnumError::A;
+}
+
+// --- explicit `::thiserror` path (same as default, exercises the code path) ---
+
+#[derive(thiserror::Error, Debug)]
+#[thiserror(crate = "::thiserror")]
+#[error("explicit path error")]
+struct ExplicitPathError;
+
+#[test]
+fn test_explicit_path_display() {
+    assert_eq!(ExplicitPathError.to_string(), "explicit path error");
+}
+
+#[test]
+fn test_explicit_path_is_error() {
+    let _: &dyn std::error::Error = &ExplicitPathError;
+}
+
+// --- #[source] works through the re-export path ---
+
+#[derive(reexport::Error, Debug)]
+#[thiserror(crate = "reexport::thiserror")]
+#[error("wrapper: {source}")]
+struct WrapperError {
+    #[source]
+    source: StructError,
+}
+
+#[test]
+fn test_source_chain() {
+    use std::error::Error;
+
+    let inner = StructError {
+        msg: "inner".into(),
+    };
+    let outer = WrapperError { source: inner };
+    assert_eq!(outer.to_string(), "wrapper: struct error: inner");
+    assert!(outer.source().is_some());
+}
+
+// --- #[from] works through the re-export path ---
+
+#[derive(reexport::Error, Debug)]
+#[thiserror(crate = "reexport::thiserror")]
+enum FromError {
+    #[error("from struct: {0}")]
+    FromStruct(#[from] StructError),
+}
+
+#[test]
+fn test_from_impl() {
+    let inner = StructError {
+        msg: "via from".into(),
+    };
+    let outer = FromError::from(inner);
+    assert_eq!(outer.to_string(), "from struct: struct error: via from");
+}
+
+// --- transparent forwarding works through the re-export path ---
+
+#[derive(reexport::Error, Debug)]
+#[thiserror(crate = "reexport::thiserror")]
+#[error(transparent)]
+struct TransparentError(StructError);
+
+#[test]
+fn test_transparent_display() {
+    let e = TransparentError(StructError {
+        msg: "inner".into(),
+    });
+    assert_eq!(e.to_string(), "struct error: inner");
+}
+
+#[test]
+fn test_transparent_source() {
+    use std::error::Error;
+    // TransparentError delegates source() to StructError, which has no #[source]
+    // field — so source() correctly returns None.
+    let e = TransparentError(StructError {
+        msg: "inner".into(),
+    });
+    assert!(e.source().is_none());
+}


### PR DESCRIPTION
When a crate re-exports `thiserror` and exposes a macro that generates `#[derive(Error)]` types, the consuming crate must still list `thiserror` as a direct dependency — because the derive unconditionally emits `::thiserror::` absolute paths into the generated code. This makes `thiserror` a leaky dependency that cannot be fully encapsulated behind a re-export.

This PR adds a `#[thiserror(crate = "...")]` container attribute, following the same pattern as `#[serde(crate = "...")]` ([serde-rs/serde#1499](https://github.com/serde-rs/serde/pull/1499)). When present, all generated paths use the specified crate root instead of `::thiserror`.

**Repro:** https://github.com/suchyj-btlnet/thiserror-reexport-repro — `consumer` fails to build because it has no direct `thiserror` dependency.

**To validate the fix**, clone this PR's branch next to the repro repo, then:
1. Uncomment `[patch.crates-io]` in the repro's root `Cargo.toml`
2. Uncomment `#[thiserror(crate = "macro_lib::thiserror")]` in `macro-lib/src/lib.rs`
3. `cargo build -p consumer` now succeeds

To be honest, @dtolnay doesn't prefer this from here https://github.com/dtolnay/thiserror/issues/167  
however @dtolnay also approved and merged this exact fix in `serde` (above). 

So I hope this PR will get merged to get this functionality also in `thiserror`

Cheers, Jacob