### PR TITLE
chore: improve thiserror maintenance path

### DIFF
--- a/tests/test_transparent.rs
+++ b/tests/test_transparent.rs
@@ -64,6 +64,37 @@ fn test_transparent_enum_with_default_message() {
 }
 
 #[test]
+fn test_transparent_enum_generic() {
+    #[derive(Error, Debug)]
+    enum Error<E> {
+        #[error("this failed")]
+        This,
+        #[error(transparent)]
+        Other(E),
+    }
+
+    #[derive(Error, Debug)]
+    #[error("inner error")]
+    struct Inner;
+
+    let error = Error::<Inner>::This;
+    assert_eq!("this failed", error.to_string());
+
+    let error = Error::Other(Inner);
+    assert_eq!("inner error", error.to_string());
+    assert!(error.source().is_none());
+
+    #[derive(Error, Debug)]
+    #[error("wrapped")]
+    struct WithSource(#[source] io::Error);
+
+    let io = io::Error::new(io::ErrorKind::Other, "oh no!");
+    let error = Error::Other(WithSource(io));
+    assert_eq!("wrapped", error.to_string());
+    assert_eq!("oh no!", error.source().unwrap().to_string());
+}
+
+#[test]
 fn test_anyhow() {
     #[derive(Error, Debug)]
     #[error(transparent)]


### PR DESCRIPTION
Summary:
- Add a small edge-case unit test covering #[error(transparent)] combined with a generic type parameter on the error enum variant, verifying both Display forwarding and source() chain behavior — extends existing test patterns without touching library code.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.